### PR TITLE
Print error message when catching exception

### DIFF
--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -26,6 +26,7 @@ const errorWrapper = (handler: express.RequestHandler): express.RequestHandler =
 		}
 		catch (error)
 		{
+			console.error(error);
 			res.sendStatus(500);
 		}
 	};


### PR DESCRIPTION
Calls `console.error` when the API router's `errorWrapper` function catches an exception, so debugging becomes slightly more convenient.