### PR TITLE
Renovate database

### DIFF
--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -373,9 +373,9 @@ class BackendConnector
 		return response.ok;
 	}
 
-	async getWords(textId: number, pageId: number): Promise<ReducedWordData[]>
+	async getWords(textId: number, pagePosition: number): Promise<ReducedWordData[]>
 	{
-		const response: Response = await fetch('/api/texts/' + textId + '/pages/' + pageId + '/words');
+		const response: Response = await fetch('/api/texts/' + textId + '/pages/' + pagePosition + '/words');
 		const words = (await response.json()).words;
 		return words;
 	}

--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -187,8 +187,8 @@ class BackendConnector
 		content: string | undefined,
 		numberOfPages: number | undefined,
 		sourceUrl: string | undefined,
-		datetimeOpened: string | undefined,
-		datetimeFinished: string | undefined,
+		timeOpened: number | undefined,
+		timeFinished: number | undefined,
 		progress: number | undefined
 	): Promise<boolean>
 	{
@@ -206,8 +206,8 @@ class BackendConnector
 						content,
 						numberOfPages,
 						sourceUrl,
-						datetimeOpened,
-						datetimeFinished,
+						timeOpened,
+						timeFinished,
 						progress,
 					}
 				),
@@ -261,8 +261,8 @@ class BackendConnector
 		status: number,
 		entries: Entry[],
 		notes: string,
-		datetimeAdded: string,
-		datetimeUpdated: string
+		timeAdded: number,
+		timeUpdated: number
 	): Promise<boolean>
 	{
 		const response: Response = await fetch(
@@ -279,8 +279,8 @@ class BackendConnector
 						status,
 						entries,
 						notes,
-						datetimeAdded,
-						datetimeUpdated,
+						timeAdded,
+						timeUpdated,
 					}
 				),
 			}
@@ -302,7 +302,7 @@ class BackendConnector
 		languageId: number,
 		contents: string[],
 		status: number,
-		datetimeAdded: string
+		timeAdded: number
 	): Promise<boolean>
 	{
 		const response: Response = await fetch(
@@ -317,7 +317,7 @@ class BackendConnector
 						languageId,
 						contents,
 						status,
-						datetimeAdded,
+						timeAdded,
 					}
 				),
 			}
@@ -340,7 +340,7 @@ class BackendConnector
 		status: number,
 		entries: Entry[],
 		notes: string,
-		datetimeUpdated: string
+		timeUpdated: number
 	): Promise<boolean>
 	{
 		const response: Response = await fetch(
@@ -355,7 +355,7 @@ class BackendConnector
 						status,
 						entries,
 						notes,
-						datetimeUpdated,
+						timeUpdated,
 					}
 				),
 			}

--- a/client/src/components/edit-word/edit-word.tsx
+++ b/client/src/components/edit-word/edit-word.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
 import { Entry, Language } from '@common/types';
+import { getUnixTime } from '../../../../common/utils';
 import { backendConnector } from '../../backend-connector';
 import { Loading } from '../loading';
 import { EntryElement } from './entry-element';
@@ -138,8 +139,8 @@ const EditWord = (
 				newStatus,
 				entriesToAdd,
 				notes ?? '',
-				new Date().toISOString(),
-				new Date().toISOString()
+				getUnixTime(),
+				getUnixTime()
 			);
 		}
 		else
@@ -149,7 +150,7 @@ const EditWord = (
 				newStatus,
 				entriesToAdd,
 				notes ?? '',
-				new Date().toISOString()
+				getUnixTime()
 			);
 		}
 

--- a/client/src/components/reader/reader.tsx
+++ b/client/src/components/reader/reader.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
 import { Language, ReducedWordData, Text } from '@common/types';
-import { itemizeString } from '../../../../common/utils';
+import { tokenizeString } from '../../../../common/utils';
 import { backendConnector } from '../../backend-connector';
 import { Loading } from '../../components/loading';
 
@@ -51,7 +51,7 @@ const getSelectionElements = (element: HTMLElement, selection: string): HTMLElem
 	let cumulativeSelection = currentElement.textContent!;
 	const elements: HTMLElement[] = [];
 
-	const selectionOnFollowingWords = itemizeString(selection).slice(1).join('');
+	const selectionOnFollowingWords = tokenizeString(selection).slice(1).join('');
 	const multiwordBeginning: string = currentElement.textContent! + selectionOnFollowingWords;
 
 	while (currentElement !== null && multiwordBeginning.startsWith(cumulativeSelection))
@@ -504,7 +504,7 @@ const Reader = (
 		}
 		else if (word.type === 'multiword')
 		{
-			const itemsInside: JSX.Element[] = word.items!.map(renderWord);
+			const tokensInside: JSX.Element[] = word.tokens!.map(renderWord);
 			const id = uuid();
 			renderedElement = (
 				<span
@@ -520,7 +520,7 @@ const Reader = (
 						cursor: "pointer",
 						boxShadow: "0 0 0 2px " + getStyle(word.status ?? 0),
 					}}
-				>{itemsInside}</span>
+				>{tokensInside}</span>
 			);
 		}
 		else

--- a/client/src/components/reader/reader.tsx
+++ b/client/src/components/reader/reader.tsx
@@ -201,10 +201,10 @@ const Reader = (
 		}
 	}
 
-	const loadPage = async (textId: number, pageId: number): Promise<void> => {
+	const loadPage = async (textId: number, pagePosition: number): Promise<void> => {
 		setIsLoading(true);
 		setWords(null);
-		setWords(await backendConnector.getWords(textId, pageId));
+		setWords(await backendConnector.getWords(textId, pagePosition));
 
 		await backendConnector.editText(
 			textData.id,
@@ -218,7 +218,7 @@ const Reader = (
 			undefined
 		);
 
-		setCurrentPage(pageId);
+		setCurrentPage(pagePosition);
 
 		document.querySelectorAll<HTMLElement>('.word').forEach(
 			(element: HTMLElement): void => {

--- a/client/src/components/reader/reader.tsx
+++ b/client/src/components/reader/reader.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
 import { Language, ReducedWordData, Text } from '@common/types';
-import { tokenizeString } from '../../../../common/utils';
+import { getUnixTime,tokenizeString } from '../../../../common/utils';
 import { backendConnector } from '../../backend-connector';
 import { Loading } from '../../components/loading';
 
@@ -170,13 +170,13 @@ const Reader = (
 
 	const updateTextStatistics = async (): Promise<void> => {
 		const newProgress = currentPage/textData.numberOfPages!;
-		const newDatetime = new Date().toISOString();
+		const newTime = getUnixTime();
 
-		const shouldUpdateDatetimeFinished: boolean = (
-			currentPage === textData.numberOfPages! && textData.datetimeFinished === null
+		const shouldUpdateTimeFinished: boolean = (
+			currentPage === textData.numberOfPages! && textData.timeFinished === null
 		);
 
-		console.log("shouldUpdateDatetimeFinished:", shouldUpdateDatetimeFinished);
+		console.log("shouldUpdateTimeFinished:", shouldUpdateTimeFinished);
 		console.log("newProgress:", newProgress);
 
 		await backendConnector.editText(
@@ -187,13 +187,13 @@ const Reader = (
 			undefined,
 			undefined,
 			undefined,
-			(shouldUpdateDatetimeFinished) ? newDatetime : undefined,
+			(shouldUpdateTimeFinished) ? newTime : undefined,
 			(newProgress > textData.progress) ? newProgress : undefined
 		);
 
-		if (shouldUpdateDatetimeFinished)
+		if (shouldUpdateTimeFinished)
 		{
-			textData.datetimeFinished = newDatetime;
+			textData.timeFinished = newTime;
 		}
 		if (newProgress > textData.progress)
 		{
@@ -213,7 +213,7 @@ const Reader = (
 			undefined,
 			undefined,
 			undefined,
-			new Date().toISOString(),
+			getUnixTime(),
 			undefined,
 			undefined
 		);
@@ -274,7 +274,7 @@ const Reader = (
 
 		newWordContents = [...new Set(newWordContents)];
 
-		await backendConnector.addWordsInBatch(languageData.id, newWordContents, status, new Date().toISOString()).then(
+		await backendConnector.addWordsInBatch(languageData.id, newWordContents, status, getUnixTime()).then(
 			(): void => {
 				for (const content of newWordContents)
 				{

--- a/common/types.ts
+++ b/common/types.ts
@@ -59,7 +59,6 @@ type RawWord = {
 	languageId: number;
 	content: string;
 	status: number;
-	entries: string,
 	notes: string;
 	datetimeAdded: string;
 	datetimeUpdated: string;

--- a/common/types.ts
+++ b/common/types.ts
@@ -24,7 +24,7 @@ type Text = {
 
 type Page = {
 	textId: number;
-	number: number;
+	position: number;
 	content: string;
 };
 

--- a/common/types.ts
+++ b/common/types.ts
@@ -33,7 +33,7 @@ type ReducedWordData = {
 	status: number | null;
 	type: string;
 	potentialMultiword: boolean | undefined;
-	items: ReducedWordData[] | undefined;
+	tokens: ReducedWordData[] | undefined;
 	index: number;
 };
 
@@ -51,7 +51,7 @@ type Word = {
 	notes: string;
 	datetimeAdded: string;
 	datetimeUpdated: string;
-	itemCount: number;
+	tokenCount: number;
 };
 
 type RawWord = {
@@ -62,7 +62,7 @@ type RawWord = {
 	notes: string;
 	datetimeAdded: string;
 	datetimeUpdated: string;
-	itemCount: number;
+	tokenCount: number;
 };
 
 export type { Language, Text, Page, ReducedWordData, Entry, Word, RawWord };

--- a/common/types.ts
+++ b/common/types.ts
@@ -17,8 +17,8 @@ type Text = {
 	title: string;
 	sourceUrl: string;
 	numberOfPages?: number;
-	datetimeOpened: string | null;
-	datetimeFinished: string | null;
+	timeOpened: number | null;
+	timeFinished: number | null;
 	progress: number;
 };
 
@@ -49,8 +49,8 @@ type Word = {
 	status: number;
 	entries: Entry[];
 	notes: string;
-	datetimeAdded: string;
-	datetimeUpdated: string;
+	timeAdded: number;
+	timeUpdated: number;
 	tokenCount: number;
 };
 
@@ -60,8 +60,8 @@ type RawWord = {
 	content: string;
 	status: number;
 	notes: string;
-	datetimeAdded: string;
-	datetimeUpdated: string;
+	timeAdded: number;
+	timeUpdated: number;
 	tokenCount: number;
 };
 

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -4,6 +4,11 @@
  * Licensed under version 3 of the GNU Affero General Public License
  */
 
+const convertIsoDatetimeToUnix = (isoDatetime: string): number =>
+{
+	return Math.floor(new Date(isoDatetime).getTime() / 1000);
+}
+
 const tokenizeString = (str: string): string[] =>
 {
 	const tokens: string[] = str.split(/([ \r\n"':;,.¿?¡!()\-=。、！？：；「」『』（）…＝・’“”—\d])/u)
@@ -12,4 +17,4 @@ const tokenizeString = (str: string): string[] =>
 	return tokens;
 }
 
-export { tokenizeString };
+export { convertIsoDatetimeToUnix, tokenizeString };

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -4,12 +4,12 @@
  * Licensed under version 3 of the GNU Affero General Public License
  */
 
-const itemizeString = (str: string): string[] =>
+const tokenizeString = (str: string): string[] =>
 {
-	const items: string[] = str.split(/([ \r\n"':;,.¿?¡!()\-=。、！？：；「」『』（）…＝・’“”—\d])/u)
+	const tokens: string[] = str.split(/([ \r\n"':;,.¿?¡!()\-=。、！？：；「」『』（）…＝・’“”—\d])/u)
 		.filter((sentence: string) => sentence !== '');
 
-	return items;
+	return tokens;
 }
 
-export { itemizeString };
+export { tokenizeString };

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -4,9 +4,9 @@
  * Licensed under version 3 of the GNU Affero General Public License
  */
 
-const convertIsoDatetimeToUnix = (isoDatetime: string): number =>
+const getUnixTime = (): number =>
 {
-	return Math.floor(new Date(isoDatetime).getTime() / 1000);
+	return Math.floor(Date.now() / 1000);
 }
 
 const tokenizeString = (str: string): string[] =>
@@ -17,4 +17,4 @@ const tokenizeString = (str: string): string[] =>
 	return tokens;
 }
 
-export { convertIsoDatetimeToUnix, tokenizeString };
+export { getUnixTime, tokenizeString };

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -21,17 +21,17 @@ class PagesController
 		return pages;
 	}
 
-	async getPage(textId: number, pageId: number): Promise<Page>
+	async getPage(textId: number, pagePosition: number): Promise<Page>
 	{
 		const page: Page = await databaseManager.getFirstRow(
 			queries.getPage,
-			[textId, pageId]
+			[textId, pagePosition]
 		);
 
 		return page;
 	}
 
-	async editPage(textId: number, index: number, content: string, pageId: number): Promise<void>
+	async editPage(textId: number, index: number, content: string, pagePosition: number): Promise<void>
 	{
 		const queryParams: any[] = [];
 		const updates: string[] = [];
@@ -45,7 +45,7 @@ class PagesController
 		if (updates.length > 0)
 		{
 			queryParams.push(textId);
-			queryParams.push(pageId);
+			queryParams.push(pagePosition);
 
 			const dynamicQuery: string = queries.editPage.replace(
 				/\%DYNAMIC\%/,
@@ -58,11 +58,11 @@ class PagesController
 		}
 	}
 
-	async getWords(textId: number, pageId: number): Promise<ReducedWordData[]>
+	async getWords(textId: number, pagePosition: number): Promise<ReducedWordData[]>
 	{
 		const page: Page = await databaseManager.getFirstRow(
 			queries.getPage,
-			[textId, pageId]
+			[textId, pagePosition]
 		);
 
 		const languageId: number = (await databaseManager.getFirstRow(

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -5,7 +5,7 @@
  */
 
 import { Page, ReducedWordData, Word } from "@common/types";
-import { itemizeString } from "../../../common/utils";
+import { tokenizeString } from "../../../common/utils";
 import { databaseManager } from "../database/database-manager";
 import { queries } from "../database/queries";
 
@@ -70,13 +70,13 @@ class PagesController
 			[page.textId]
 		)).languageId;
 
-		const items: string[] = itemizeString(page.content);
+		const tokens: string[] = tokenizeString(page.content);
 		
 		const dynamicQuery: string = queries.findWordsInBatch.replace(
 			/\%DYNAMIC\%/,
 			(): string => {
-				return items.map((item: string): string => {
-					return `('${item.replace(/'/g, "''")}')`;
+				return tokens.map((token: string): string => {
+					return `('${token.replace(/'/g, "''")}')`;
 				}).join(', ');
 			}
 		);
@@ -96,19 +96,19 @@ class PagesController
 				);
 
 				let multiword: Word | null = null;
-				let itemCount: number | null = null;
-				let items: ReducedWordData[] | null = null;
+				let tokenCount: number | null = null;
+				let tokens: ReducedWordData[] | null = null;
 
 				for (const potentialMultiword of potentialMultiwords)
 				{
-					itemCount = potentialMultiword.itemCount;
+					tokenCount = potentialMultiword.tokenCount;
 
-					items = wordData.slice(i, i + itemCount);
-					const itemsContent: string = items.map((item: ReducedWordData): string => {
-						return item.content;
+					tokens = wordData.slice(i, i + tokenCount);
+					const tokensContent: string = tokens.map((token: ReducedWordData): string => {
+						return token.content;
 					}).join('');
 
-					if (itemsContent === potentialMultiword.content)
+					if (tokensContent === potentialMultiword.content)
 					{
 						multiword = potentialMultiword;
 						break;
@@ -117,16 +117,16 @@ class PagesController
 
 				if(multiword)
 				{
-					wordData.splice(i, multiword.itemCount, {
+					wordData.splice(i, multiword.tokenCount, {
 						content: multiword.content,
 						status: multiword.status,
 						type: "multiword",
-						items: items!,
+						tokens: tokens!,
 						potentialMultiword: undefined,
 						index: -1
 					});
 
-					i += multiword.itemCount - 1;
+					i += multiword.tokenCount - 1;
 				}
 			}
 
@@ -145,15 +145,15 @@ class PagesController
 			wordData[i].index = i+startIndex;
 			if(wordData[i].type === "multiword")
 			{
-				this.addIndexesToWordData(wordData[i].items!, wordData[i].index+1);
-				startIndex += wordData[i].items!.length;
+				this.addIndexesToWordData(wordData[i].tokens!, wordData[i].index+1);
+				startIndex += wordData[i].tokens!.length;
 			}
 		}
 	}
 	
-	isWord(item: string): boolean
+	isWord(token: string): boolean
 	{
-		return (item.match(/[ :;,.¿?¡!()\[\]{}\s'"\-=。、！？：；「」『』（）…＝・’“”—\d]/u) === null);
+		return (token.match(/[ :;,.¿?¡!()\[\]{}\s'"\-=。、！？：；「」『』（）…＝・’“”—\d]/u) === null);
 	}
 }
 

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -11,10 +11,10 @@ import { queries } from "../database/queries";
 
 class PagesController
 {
-	async getAllPages(textId: number): Promise<Page[]>
+	async getPagesByText(textId: number): Promise<Page[]>
 	{
 		const pages: Page[] = await databaseManager.executeQuery(
-			queries.getAllPages,
+			queries.getPagesByText,
 			[textId]
 		);
 

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -5,6 +5,7 @@
  */
 
 import { Page, Text } from '@common/types';
+import { convertIsoDatetimeToUnix } from '../../../common/utils';
 import { databaseManager } from "../database/database-manager";
 import { queries } from "../database/queries";
 
@@ -119,13 +120,17 @@ class TextsController
 		}
 		if (datetimeOpened !== undefined)
 		{
-			updates.push('datetime_opened = ?');
-			queryParams.push(datetimeOpened);
+			const timeOpened: number = convertIsoDatetimeToUnix(datetimeOpened);
+
+			updates.push('time_opened = ?');
+			queryParams.push(timeOpened);
 		}
 		if (datetimeFinished !== undefined)
 		{
-			updates.push('datetime_finished = ?');
-			queryParams.push(datetimeFinished);
+			const timeFinished: number = convertIsoDatetimeToUnix(datetimeFinished);
+
+			updates.push('time_finished = ?');
+			queryParams.push(timeFinished);
 		}
 		if (progress !== undefined)
 		{

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -5,7 +5,6 @@
  */
 
 import { Page, Text } from '@common/types';
-import { convertIsoDatetimeToUnix } from '../../../common/utils';
 import { databaseManager } from "../database/database-manager";
 import { queries } from "../database/queries";
 
@@ -86,8 +85,8 @@ class TextsController
 		numberOfPages: number,
 		content: string,
 		textId: number,
-		datetimeOpened: string,
-		datetimeFinished: string,
+		timeOpened: number,
+		timeFinished: number,
 		progress: number
 	): Promise<void>
 	{
@@ -118,17 +117,13 @@ class TextsController
 			updates.push('source_url = ?');
 			queryParams.push(sourceUrl);
 		}
-		if (datetimeOpened !== undefined)
+		if (timeOpened !== undefined)
 		{
-			const timeOpened: number = convertIsoDatetimeToUnix(datetimeOpened);
-
 			updates.push('time_opened = ?');
 			queryParams.push(timeOpened);
 		}
-		if (datetimeFinished !== undefined)
+		if (timeFinished !== undefined)
 		{
-			const timeFinished: number = convertIsoDatetimeToUnix(datetimeFinished);
-
 			updates.push('time_finished = ?');
 			queryParams.push(timeFinished);
 		}

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -202,8 +202,8 @@ class TextsController
 				/\%DYNAMIC\%/,
 				(): string => {
 					return newPageContents.slice(pages.length).map(
-						(item: string, index: number): string => {
-							return `(${textId}, ${index + pages.length + 1}, '${item.replace(/'/g, "''")}')`;
+						(token: string, index: number): string => {
+							return `(${textId}, ${index + pages.length + 1}, '${token.replace(/'/g, "''")}')`;
 						}
 					).join(', ');
 				}

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -58,7 +58,7 @@ class TextsController
 	async getNumberOfPages(textId: number): Promise<number>
 	{
 		const numberOfPages: number = (await databaseManager.executeQuery(
-			queries.getAllPages,
+			queries.getPagesByText,
 			[textId]
 		)).length;
 
@@ -68,7 +68,7 @@ class TextsController
 	async deleteText(textId: number): Promise<void>
 	{
 		const pages: Page[] = await databaseManager.executeQuery(
-			queries.getAllPages,
+			queries.getPagesByText,
 			[textId]
 		);
 		for (const page of pages)
@@ -162,7 +162,7 @@ class TextsController
 	private async updatePage(textId: number, numberOfPages: number, content: string)
 	{
 		const pages: Page[] = await databaseManager.executeQuery(
-			queries.getAllPages,
+			queries.getPagesByText,
 			[textId]
 		);
 

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -213,6 +213,11 @@ class WordsController
 			[wordId]
 		);
 
+		if (!entries || entries.length === 0)
+		{
+			return;
+		}
+
 		const dynamicQuery: string = queries.addEntriesInBatch.replace(
 			/\%DYNAMIC\%/,
 			(): string => {

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -5,7 +5,7 @@
  */
 
 import { Entry, RawWord, Word } from "@common/types";
-import { itemizeString } from "../../../common/utils";
+import { tokenizeString } from "../../../common/utils";
 import { databaseManager } from "../database/database-manager";
 import { queries } from "../database/queries";
 
@@ -21,11 +21,11 @@ class WordsController
 		datetimeUpdated: string
 	): Promise<void>
 	{
-		const itemizedContent: string[] = itemizeString(content);
+		const tokenizedContent: string[] = tokenizeString(content);
 
 		await databaseManager.executeQuery(
 			queries.addWord,
-			[languageId, content, status, notes, datetimeAdded, datetimeUpdated, itemizedContent.length]
+			[languageId, content, status, notes, datetimeAdded, datetimeUpdated, tokenizedContent.length]
 		);
 
 		const wordId: number = (await databaseManager.getLastInsertId()).id;
@@ -49,10 +49,10 @@ class WordsController
 		const valueList: string[] = [];
 		for (const content of contents)
 		{
-			const itemizedContent: string[] = itemizeString(content);
+			const tokenizedContent: string[] = tokenizeString(content);
 
 			valueList.push(
-				`(${languageId}, '${content}', ${status}, '', '${datetimeAdded}', '${datetimeAdded}', ${itemizedContent.length})`
+				`(${languageId}, '${content}', ${status}, '', '${datetimeAdded}', '${datetimeAdded}', ${tokenizedContent.length})`
 			);
 		}
 
@@ -152,10 +152,10 @@ class WordsController
 			updates.push('content = ?');
 			queryParams.push(content);
 
-			const itemizedContent: string[] = itemizeString(content);
+			const tokenizedContent: string[] = tokenizeString(content);
 
-			updates.push('item_count = ?');
-			queryParams.push(itemizedContent.length);
+			updates.push('token_count = ?');
+			queryParams.push(tokenizedContent.length);
 		}
 		if (status !== undefined)
 		{
@@ -208,11 +208,11 @@ class WordsController
 			/\%DYNAMIC\%/,
 			(): string => {
 				return entries.map(
-					(item: Entry, index: number): string => {
+					(token: Entry, index: number): string => {
 						return `(${wordId},
 								${index + 1},
-								'${item.meaning.replace(/'/g, "''")}',
-								'${item.reading.replace(/'/g, "''")}'
+								'${token.meaning.replace(/'/g, "''")}',
+								'${token.reading.replace(/'/g, "''")}'
 							)`;
 					}
 				).join(', ');

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -204,13 +204,22 @@ class WordsController
 			[wordId]
 		);
 
-		for (let i = 0; i < entries.length; i++)
-		{
-			await databaseManager.executeQuery(
-				queries.addEntry,
-				[wordId, i, entries[i].meaning, entries[i].reading]
-			);
-		}
+		const dynamicQuery: string = queries.addEntriesInBatch.replace(
+			/\%DYNAMIC\%/,
+			(): string => {
+				return entries.map(
+					(item: Entry, index: number): string => {
+						return `(${wordId},
+								${index + 1},
+								'${item.meaning.replace(/'/g, "''")}',
+								'${item.reading.replace(/'/g, "''")}'
+							)`;
+					}
+				).join(', ');
+			}
+		);
+
+		await databaseManager.executeQuery(dynamicQuery);
 	}
 }
 

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -5,7 +5,7 @@
  */
 
 import { Entry, RawWord, Word } from "@common/types";
-import { convertIsoDatetimeToUnix, tokenizeString } from "../../../common/utils";
+import { tokenizeString } from "../../../common/utils";
 import { databaseManager } from "../database/database-manager";
 import { queries } from "../database/queries";
 
@@ -17,14 +17,11 @@ class WordsController
 		status: number,
 		entries: Entry[],
 		notes: string,
-		datetimeAdded: string,
-		datetimeUpdated: string
+		timeAdded: number,
+		timeUpdated: number
 	): Promise<void>
 	{
 		const tokenizedContent: string[] = tokenizeString(content);
-
-		const timeAdded = convertIsoDatetimeToUnix(datetimeAdded);
-		const timeUpdated = convertIsoDatetimeToUnix(datetimeUpdated);
 
 		await databaseManager.executeQuery(
 			queries.addWord,
@@ -46,15 +43,13 @@ class WordsController
 		languageId: number,
 		contents: string[],
 		status: number,
-		datetimeAdded: string
+		timeAdded: number
 	): Promise<void>
 	{
 		const valueList: string[] = [];
 		for (const content of contents)
 		{
 			const tokenizedContent: string[] = tokenizeString(content);
-
-			const timeAdded = convertIsoDatetimeToUnix(datetimeAdded);
 
 			valueList.push(
 				`(${languageId}, '${content}', ${status}, '', '${timeAdded}', '${timeAdded}', ${tokenizedContent.length})`
@@ -130,8 +125,8 @@ class WordsController
 		status: number,
 		entries: Entry[],
 		notes: string,
-		datetimeAdded: string,
-		datetimeUpdated: string,
+		timeAdded: number,
+		timeUpdated: number,
 		wordId: number
 	): Promise<void>
 	{
@@ -176,17 +171,13 @@ class WordsController
 			updates.push('notes = ?');
 			queryParams.push(notes);
 		}
-		if (datetimeAdded !== undefined)
+		if (timeAdded !== undefined)
 		{
-			const timeAdded = convertIsoDatetimeToUnix(datetimeAdded);
-
 			updates.push('time_added = ?');
 			queryParams.push(timeAdded);
 		}
-		if (datetimeUpdated !== undefined)
+		if (timeUpdated !== undefined)
 		{
-			const timeUpdated = convertIsoDatetimeToUnix(datetimeUpdated);
-
 			updates.push('time_updated = ?');
 			queryParams.push(timeUpdated);
 		}

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -5,7 +5,7 @@
  */
 
 import { Entry, RawWord, Word } from "@common/types";
-import { tokenizeString } from "../../../common/utils";
+import { convertIsoDatetimeToUnix, tokenizeString } from "../../../common/utils";
 import { databaseManager } from "../database/database-manager";
 import { queries } from "../database/queries";
 
@@ -23,9 +23,12 @@ class WordsController
 	{
 		const tokenizedContent: string[] = tokenizeString(content);
 
+		const timeAdded = convertIsoDatetimeToUnix(datetimeAdded);
+		const timeUpdated = convertIsoDatetimeToUnix(datetimeUpdated);
+
 		await databaseManager.executeQuery(
 			queries.addWord,
-			[languageId, content, status, notes, datetimeAdded, datetimeUpdated, tokenizedContent.length]
+			[languageId, content, status, notes, timeAdded, timeUpdated, tokenizedContent.length]
 		);
 
 		const wordId: number = (await databaseManager.getLastInsertId()).id;
@@ -51,8 +54,10 @@ class WordsController
 		{
 			const tokenizedContent: string[] = tokenizeString(content);
 
+			const timeAdded = convertIsoDatetimeToUnix(datetimeAdded);
+
 			valueList.push(
-				`(${languageId}, '${content}', ${status}, '', '${datetimeAdded}', '${datetimeAdded}', ${tokenizedContent.length})`
+				`(${languageId}, '${content}', ${status}, '', '${timeAdded}', '${timeAdded}', ${tokenizedContent.length})`
 			);
 		}
 
@@ -173,13 +178,17 @@ class WordsController
 		}
 		if (datetimeAdded !== undefined)
 		{
-			updates.push('datetime_added = ?');
-			queryParams.push(datetimeAdded);
+			const timeAdded = convertIsoDatetimeToUnix(datetimeAdded);
+
+			updates.push('time_added = ?');
+			queryParams.push(timeAdded);
 		}
 		if (datetimeUpdated !== undefined)
 		{
-			updates.push('datetime_updated = ?');
-			queryParams.push(datetimeUpdated);
+			const timeUpdated = convertIsoDatetimeToUnix(datetimeUpdated);
+
+			updates.push('time_updated = ?');
+			queryParams.push(timeUpdated);
 		}
 
 		if (updates.length > 0)

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -72,6 +72,7 @@ class DatabaseManager
 		await this.executeQuery(queries.createTextTable);
 		await this.executeQuery(queries.createPageTable);
 		await this.executeQuery(queries.createWordTable);
+		await this.executeQuery(queries.createEntryTable);
 
 		// Create indexes
 		await this.executeQuery(queries.createTextLanguageIdTitleIndex);

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -59,18 +59,24 @@ class DatabaseManager
 			}
 		);
 
-		this.createTables();
+		this.initializeDatabase();
 
 		DatabaseManager.instance = this;
 	}
 
-	createTables(): void
+	async initializeDatabase(): Promise<void>
 	{
-		this.database.run(queries.createConfigurationTable);
-		this.database.run(queries.createLanguageTable);
-		this.database.run(queries.createTextTable);
-		this.database.run(queries.createPageTable);
-		this.database.run(queries.createWordTable);
+		// Create tables
+		await this.executeQuery(queries.createConfigurationTable);
+		await this.executeQuery(queries.createLanguageTable);
+		await this.executeQuery(queries.createTextTable);
+		await this.executeQuery(queries.createPageTable);
+		await this.executeQuery(queries.createWordTable);
+
+		// Create indexes
+		await this.executeQuery(queries.createTextLanguageIdTitleIndex);
+		await this.executeQuery(queries.createWordLowerContentLanguageIdIndex);
+		await this.executeQuery(queries.createWordLanguageIdItemCountContentIndex);
 	}
 
 	executeQuery(query: string, parameters: any[] = []): Promise<any>

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -77,7 +77,7 @@ class DatabaseManager
 		// Create indexes
 		await this.executeQuery(queries.createTextLanguageIdTitleIndex);
 		await this.executeQuery(queries.createWordLowerContentLanguageIdIndex);
-		await this.executeQuery(queries.createWordLanguageIdItemCountContentIndex);
+		await this.executeQuery(queries.createWordLanguageIdTokenCountContentIndex);
 	}
 
 	executeQuery(query: string, parameters: any[] = []): Promise<any>

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -45,7 +45,6 @@ const queries: { [key: string]: string } = {
 		language_id INTEGER NOT NULL,
 		content TEXT NOT NULL,
 		status INTEGER NOT NULL DEFAULT 0,
-		entries TEXT,
 		notes TEXT,
 		datetime_added TEXT NOT NULL,
 		datetime_updated TEXT NOT NULL,
@@ -53,6 +52,16 @@ const queries: { [key: string]: string } = {
 		CONSTRAINT pk__word__id PRIMARY KEY (id),
 		CONSTRAINT fk__word__language_id FOREIGN KEY (language_id) REFERENCES language (id),
 		CONSTRAINT uq__word__language_id__content UNIQUE (language_id, content)
+	)`,
+	createEntryTable: `CREATE TABLE IF NOT EXISTS entry (
+		id INTEGER,
+		word_id INTEGER NOT NULL,
+		number INTEGER NOT NULL,
+		meaning TEXT NOT NULL,
+		reading TEXT NOT NULL,
+		CONSTRAINT pk__entry__id PRIMARY KEY (id),
+		CONSTRAINT fk__entry__word_id FOREIGN KEY (word_id) REFERENCES word (id),
+		CONSTRAINT uq__entry__word_id__number UNIQUE (word_id, number)
 	)`,
 	//#endregion
 
@@ -163,7 +172,6 @@ const queries: { [key: string]: string } = {
 			language_id AS languageId,
 			content,
 			status,
-			entries,
 			notes,
 			datetime_added AS datetimeAdded,
 			datetime_updated AS datetimeUpdated,
@@ -175,7 +183,6 @@ const queries: { [key: string]: string } = {
 			language_id AS languageId,
 			content,
 			status,
-			entries,
 			notes,
 			datetime_added AS datetimeAdded,
 			datetime_updated AS datetimeUpdated,
@@ -205,18 +212,16 @@ const queries: { [key: string]: string } = {
 			language_id,
 			content,
 			status,
-			entries,
 			notes,
 			datetime_added,
 			datetime_updated,
 			item_count
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
 	addWordsInBatch: `INSERT INTO word (
 			language_id,
 			content,
 			status,
-			entries,
 			notes,
 			datetime_added,
 			datetime_updated,
@@ -230,7 +235,6 @@ const queries: { [key: string]: string } = {
 			language_id AS languageId,
 			content,
 			status,
-			entries,
 			notes,
 			datetime_added AS datetimeAdded,
 			datetime_updated AS datetimeUpdated,
@@ -239,6 +243,23 @@ const queries: { [key: string]: string } = {
 		WHERE content LIKE (? || '%')
 			AND language_id = ?
 			AND item_count > 1`,
+	//#endregion
+
+	//#region Entry
+	getEntriesByWord: `SELECT
+			meaning,
+			reading
+		FROM entry
+		WHERE word_id = ?
+		ORDER BY number ASC`,
+	addEntry: `INSERT INTO entry (
+			word_id,
+			number,
+			meaning,
+			reading
+		)
+		VALUES (?, ?, ?, ?)`,
+	deleteEntriesByWord: `DELETE FROM entry WHERE word_id = ?`,
 	//#endregion
 
 	//#region Utils

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -24,8 +24,8 @@ const queries: { [key: string]: string } = {
 		language_id INTEGER NOT NULL,
 		title TEXT NOT NULL,
 		source_url TEXT,
-		datetime_opened TEXT,
-		datetime_finished TEXT,
+		time_opened INTEGER,
+		time_finished INTEGER,
 		progress REAL NOT NULL DEFAULT 0,
 		CONSTRAINT pk__text__id PRIMARY KEY (id),
 		CONSTRAINT fk__text__language_id FOREIGN KEY (language_id) REFERENCES language (id),
@@ -46,8 +46,8 @@ const queries: { [key: string]: string } = {
 		content TEXT NOT NULL,
 		status INTEGER NOT NULL DEFAULT 0,
 		notes TEXT,
-		datetime_added TEXT NOT NULL,
-		datetime_updated TEXT NOT NULL,
+		time_added INTEGER NOT NULL,
+		time_updated INTEGER NOT NULL,
 		token_count INTEGER NOT NULL DEFAULT 1,
 		CONSTRAINT pk__word__id PRIMARY KEY (id),
 		CONSTRAINT fk__word__language_id FOREIGN KEY (language_id) REFERENCES language (id),
@@ -109,8 +109,8 @@ const queries: { [key: string]: string } = {
 			language_id AS languageId,
 			title,
 			source_url AS sourceUrl,
-			datetime_opened AS datetimeOpened,
-			datetime_finished AS datetimeFinished,
+			time_opened AS timeOpened,
+			time_finished AS timeFinished,
 			progress
 		FROM text`,
 	getTextsByLanguage: `SELECT
@@ -118,8 +118,8 @@ const queries: { [key: string]: string } = {
 			language_id AS languageId,
 			title,
 			source_url AS sourceUrl,
-			datetime_opened AS datetimeOpened,
-			datetime_finished AS datetimeFinished,
+			time_opened AS timeOpened,
+			time_finished AS timeFinished,
 			progress
 		FROM text
 		WHERE language_id = ?`,
@@ -128,8 +128,8 @@ const queries: { [key: string]: string } = {
 			language_id AS languageId,
 			title,
 			source_url AS sourceUrl,
-			datetime_opened AS datetimeOpened,
-			datetime_finished AS datetimeFinished,
+			time_opened AS timeOpened,
+			time_finished AS timeFinished,
 			progress
 		FROM text
 		WHERE id = ?`,
@@ -181,8 +181,8 @@ const queries: { [key: string]: string } = {
 			content,
 			status,
 			notes,
-			datetime_added AS datetimeAdded,
-			datetime_updated AS datetimeUpdated,
+			time_added AS timeAdded,
+			time_updated AS timeUpdated,
 			token_count AS tokenCount
 		FROM word
 		WHERE id = ?`,
@@ -192,8 +192,8 @@ const queries: { [key: string]: string } = {
 			content,
 			status,
 			notes,
-			datetime_added AS datetimeAdded,
-			datetime_updated AS datetimeUpdated,
+			time_added AS timeAdded,
+			time_updated AS timeUpdated,
 			token_count AS tokenCount
 		FROM word
 		WHERE LOWER(content) = LOWER(?) AND language_id = ?`,
@@ -221,8 +221,8 @@ const queries: { [key: string]: string } = {
 			content,
 			status,
 			notes,
-			datetime_added,
-			datetime_updated,
+			time_added,
+			time_updated,
 			token_count
 		)
 		VALUES (?, ?, ?, ?, ?, ?, ?)`,
@@ -231,8 +231,8 @@ const queries: { [key: string]: string } = {
 			content,
 			status,
 			notes,
-			datetime_added,
-			datetime_updated,
+			time_added,
+			time_updated,
 			token_count
 		)
 		VALUES %DYNAMIC%`,
@@ -244,8 +244,8 @@ const queries: { [key: string]: string } = {
 			content,
 			status,
 			notes,
-			datetime_added AS datetimeAdded,
-			datetime_updated AS datetimeUpdated,
+			time_added AS timeAdded,
+			time_updated AS timeUpdated,
 			token_count AS tokenCount
 		FROM word
 		WHERE content LIKE (? || '%')

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -7,35 +7,39 @@
 const queries: { [key: string]: string } = {
 	//#region Create tables
 	createConfigurationTable: `CREATE TABLE IF NOT EXISTS configuration (
-		key TEXT NOT NULL PRIMARY KEY,
-		value TEXT
+		key TEXT NOT NULL,
+		value TEXT,
+		CONSTRAINT pk__configuration__key PRIMARY KEY (key)
 	)`,
 	createLanguageTable: `CREATE TABLE IF NOT EXISTS language (
-		id INTEGER PRIMARY KEY,
-		name TEXT NOT NULL UNIQUE,
+		id INTEGER,
+		name TEXT NOT NULL,
 		dictionary_url TEXT,
-		should_show_spaces INTEGER NOT NULL DEFAULT 1
+		should_show_spaces INTEGER NOT NULL DEFAULT 1,
+		CONSTRAINT pk__language__id PRIMARY KEY (id),
+		CONSTRAINT uq__language__name UNIQUE (name)
 	)`,
 	createTextTable: `CREATE TABLE IF NOT EXISTS text (
-		id INTEGER PRIMARY KEY,
+		id INTEGER,
 		language_id INTEGER NOT NULL,
 		title TEXT NOT NULL,
 		source_url TEXT,
 		datetime_opened TEXT,
 		datetime_finished TEXT,
 		progress REAL NOT NULL DEFAULT 0,
-		FOREIGN KEY(language_id) REFERENCES language(id),
-		UNIQUE(language_id, title)
+		CONSTRAINT pk__text__id PRIMARY KEY (id),
+		CONSTRAINT fk__text__language_id FOREIGN KEY (language_id) REFERENCES language (id),
+		CONSTRAINT uq__text__language_id__title UNIQUE (language_id, title)
 	)`,
 	createPageTable: `CREATE TABLE IF NOT EXISTS page (
 		text_id INTEGER NOT NULL,
 		number INTEGER NOT NULL,
 		content TEXT NOT NULL,
-		FOREIGN KEY(text_id) REFERENCES text(id),
-		UNIQUE(text_id, number)
+		CONSTRAINT pk__page__text_id__number PRIMARY KEY (text_id, number),
+		CONSTRAINT fk__page__text_id FOREIGN KEY (text_id) REFERENCES text (id)
 	)`,
 	createWordTable: `CREATE TABLE IF NOT EXISTS word (
-		id INTEGER PRIMARY KEY,
+		id INTEGER,
 		language_id INTEGER NOT NULL,
 		content TEXT NOT NULL,
 		status INTEGER NOT NULL DEFAULT 0,
@@ -44,8 +48,9 @@ const queries: { [key: string]: string } = {
 		datetime_added TEXT NOT NULL,
 		datetime_updated TEXT NOT NULL,
 		item_count INTEGER NOT NULL DEFAULT 1,
-		FOREIGN KEY(language_id) REFERENCES language(id),
-		UNIQUE(language_id, content)
+		CONSTRAINT pk__word__id PRIMARY KEY (id),
+		CONSTRAINT fk__word__language_id FOREIGN KEY (language_id) REFERENCES language (id),
+		CONSTRAINT uq__word__language_id__content UNIQUE (language_id, content)
 	)`,
 	//#endregion
 

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -24,7 +24,8 @@ const queries: { [key: string]: string } = {
 		datetime_opened TEXT,
 		datetime_finished TEXT,
 		progress REAL NOT NULL DEFAULT 0,
-		FOREIGN KEY(language_id) REFERENCES language(id)
+		FOREIGN KEY(language_id) REFERENCES language(id),
+		UNIQUE(language_id, title)
 	)`,
 	createPageTable: `CREATE TABLE IF NOT EXISTS page (
 		text_id INTEGER NOT NULL,
@@ -43,7 +44,8 @@ const queries: { [key: string]: string } = {
 		datetime_added TEXT NOT NULL,
 		datetime_updated TEXT NOT NULL,
 		item_count INTEGER NOT NULL DEFAULT 1,
-		FOREIGN KEY(language_id) REFERENCES language(id)
+		FOREIGN KEY(language_id) REFERENCES language(id),
+		UNIQUE(language_id, content)
 	)`,
 	//#endregion
 

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -267,6 +267,13 @@ const queries: { [key: string]: string } = {
 			reading
 		)
 		VALUES (?, ?, ?, ?)`,
+	addEntriesInBatch: `INSERT INTO entry (
+			word_id,
+			number,
+			meaning,
+			reading
+		)
+		VALUES %DYNAMIC%`,
 	deleteEntriesByWord: `DELETE FROM entry WHERE word_id = ?`,
 	//#endregion
 

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -32,8 +32,8 @@ const queries: { [key: string]: string } = {
 		CONSTRAINT uq__text__language_id__title UNIQUE (language_id, title)
 	)`,
 	createPageTable: `CREATE TABLE IF NOT EXISTS page (
-		text_id INTEGER NOT NULL,
-		number INTEGER NOT NULL,
+		text_id INTEGER,
+		number INTEGER,
 		content TEXT NOT NULL,
 		CONSTRAINT pk__page__text_id__number PRIMARY KEY (text_id, number),
 		CONSTRAINT fk__page__text_id FOREIGN KEY (text_id) REFERENCES text (id)
@@ -52,6 +52,21 @@ const queries: { [key: string]: string } = {
 		CONSTRAINT fk__word__language_id FOREIGN KEY (language_id) REFERENCES language (id),
 		CONSTRAINT uq__word__language_id__content UNIQUE (language_id, content)
 	)`,
+	//#endregion
+
+	//#region Create indexes
+	createTextLanguageIdTitleIndex: `CREATE INDEX IF NOT EXISTS
+		ix__text__language_id__title ON text (
+			language_id, title
+		)`,
+	createWordLowerContentLanguageIdIndex: `CREATE INDEX IF NOT EXISTS
+		ix__word__lower_content__language_id ON word (
+			LOWER(content), language_id
+		)`,
+	createWordLanguageIdItemCountContentIndex: `CREATE INDEX IF NOT EXISTS
+		ix__word__language_id__item_count__content ON word (
+			language_id, item_count, content
+		)`,
 	//#endregion
 
 	//#region Language

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -48,7 +48,7 @@ const queries: { [key: string]: string } = {
 		notes TEXT,
 		datetime_added TEXT NOT NULL,
 		datetime_updated TEXT NOT NULL,
-		item_count INTEGER NOT NULL DEFAULT 1,
+		token_count INTEGER NOT NULL DEFAULT 1,
 		CONSTRAINT pk__word__id PRIMARY KEY (id),
 		CONSTRAINT fk__word__language_id FOREIGN KEY (language_id) REFERENCES language (id),
 		CONSTRAINT uq__word__language_id__content UNIQUE (language_id, content)
@@ -74,9 +74,9 @@ const queries: { [key: string]: string } = {
 		ix__word__lower_content__language_id ON word (
 			LOWER(content), language_id
 		)`,
-	createWordLanguageIdItemCountContentIndex: `CREATE INDEX IF NOT EXISTS
-		ix__word__language_id__item_count__content ON word (
-			language_id, item_count, content
+	createWordLanguageIdTokenCountContentIndex: `CREATE INDEX IF NOT EXISTS
+		ix__word__language_id__token_count__content ON word (
+			language_id, token_count, content
 		)`,
 	//#endregion
 
@@ -183,7 +183,7 @@ const queries: { [key: string]: string } = {
 			notes,
 			datetime_added AS datetimeAdded,
 			datetime_updated AS datetimeUpdated,
-			item_count AS itemCount
+			token_count AS tokenCount
 		FROM word
 		WHERE id = ?`,
 	findWord: `SELECT
@@ -194,7 +194,7 @@ const queries: { [key: string]: string } = {
 			notes,
 			datetime_added AS datetimeAdded,
 			datetime_updated AS datetimeUpdated,
-			item_count AS itemCount
+			token_count AS tokenCount
 		FROM word
 		WHERE LOWER(content) = LOWER(?) AND language_id = ?`,
 	findWordsInBatch: `WITH input_words(content) AS (VALUES %DYNAMIC%)
@@ -210,9 +210,9 @@ const queries: { [key: string]: string } = {
 				ELSE 'punctuation'
 			END AS type,
 			EXISTS (
-				SELECT item_count
+				SELECT token_count
 				FROM word
-				WHERE word.content LIKE (input_words.content || '%') AND word.language_id = ? AND word.item_count > 1
+				WHERE word.content LIKE (input_words.content || '%') AND word.language_id = ? AND word.token_count > 1
 			) AS potentialMultiword
 		FROM input_words
 		LEFT JOIN word ON LOWER(input_words.content) = LOWER(word.content) AND word.language_id = ?`,
@@ -223,7 +223,7 @@ const queries: { [key: string]: string } = {
 			notes,
 			datetime_added,
 			datetime_updated,
-			item_count
+			token_count
 		)
 		VALUES (?, ?, ?, ?, ?, ?, ?)`,
 	addWordsInBatch: `INSERT INTO word (
@@ -233,7 +233,7 @@ const queries: { [key: string]: string } = {
 			notes,
 			datetime_added,
 			datetime_updated,
-			item_count
+			token_count
 		)
 		VALUES %DYNAMIC%`,
 	deleteWord: `DELETE FROM word WHERE id = ?`,
@@ -246,11 +246,11 @@ const queries: { [key: string]: string } = {
 			notes,
 			datetime_added AS datetimeAdded,
 			datetime_updated AS datetimeUpdated,
-			item_count AS itemCount
+			token_count AS tokenCount
 		FROM word
 		WHERE content LIKE (? || '%')
 			AND language_id = ?
-			AND item_count > 1`,
+			AND token_count > 1`,
 	//#endregion
 
 	//#region Entry

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -11,13 +11,13 @@ const queries: { [key: string]: string } = {
 		value TEXT
 	)`,
 	createLanguageTable: `CREATE TABLE IF NOT EXISTS language (
-		id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+		id INTEGER PRIMARY KEY,
 		name TEXT NOT NULL UNIQUE,
 		dictionary_url TEXT,
 		should_show_spaces INTEGER NOT NULL DEFAULT 1
 	)`,
 	createTextTable: `CREATE TABLE IF NOT EXISTS text (
-		id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+		id INTEGER PRIMARY KEY,
 		language_id INTEGER NOT NULL,
 		title TEXT NOT NULL,
 		source_url TEXT,
@@ -34,7 +34,7 @@ const queries: { [key: string]: string } = {
 		UNIQUE(text_id, number)
 	)`,
 	createWordTable: `CREATE TABLE IF NOT EXISTS word (
-		id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+		id INTEGER PRIMARY KEY,
 		language_id INTEGER NOT NULL,
 		content TEXT NOT NULL,
 		status INTEGER NOT NULL DEFAULT 0,

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -34,11 +34,11 @@ const queries: { [key: string]: string } = {
 	createPageTable: `CREATE TABLE IF NOT EXISTS page (
 		id INTEGER,
 		text_id INTEGER,
-		number INTEGER,
+		position INTEGER,
 		content TEXT NOT NULL,
 		CONSTRAINT pk__page__id PRIMARY KEY (id),
 		CONSTRAINT fk__page__text_id FOREIGN KEY (text_id) REFERENCES text (id)
-		CONSTRAINT uq__page__text_id__number UNIQUE (text_id, number)
+		CONSTRAINT uq__page__text_id__position UNIQUE (text_id, position)
 	)`,
 	createWordTable: `CREATE TABLE IF NOT EXISTS word (
 		id INTEGER,
@@ -56,12 +56,12 @@ const queries: { [key: string]: string } = {
 	createEntryTable: `CREATE TABLE IF NOT EXISTS entry (
 		id INTEGER,
 		word_id INTEGER NOT NULL,
-		number INTEGER NOT NULL,
+		position INTEGER NOT NULL,
 		meaning TEXT NOT NULL,
 		reading TEXT NOT NULL,
 		CONSTRAINT pk__entry__id PRIMARY KEY (id),
 		CONSTRAINT fk__entry__word_id FOREIGN KEY (word_id) REFERENCES word (id),
-		CONSTRAINT uq__entry__word_id__number UNIQUE (word_id, number)
+		CONSTRAINT uq__entry__word_id__position UNIQUE (word_id, position)
 	)`,
 	//#endregion
 
@@ -146,32 +146,32 @@ const queries: { [key: string]: string } = {
 	//#region Page
 	getPagesByText: `SELECT
 			text_id AS textId,
-			number,
+			position,
 			content
 		FROM page
 		WHERE text_id = ?`,
 	getPage: `SELECT
 			text_id AS textId,
-			number,
+			position,
 			content
 		FROM page
-		WHERE text_id = ? AND number = ?`,
+		WHERE text_id = ? AND position = ?`,
 	addPage: `INSERT INTO page (
 			text_id,
-			number,
+			position,
 			content
 		)
 		VALUES (?, ?, ?)`,
 	addPagesInBatch: `INSERT INTO page (
 			text_id,
-			number,
+			position,
 			content
 		)
 		VALUES %DYNAMIC%`,
-	deletePage: `DELETE FROM page WHERE text_id = ? AND number = ?`,
-	deletePagesInBatch: `DELETE FROM page WHERE text_id = ? AND number >= ?`,
+	deletePage: `DELETE FROM page WHERE text_id = ? AND position = ?`,
+	deletePagesInBatch: `DELETE FROM page WHERE text_id = ? AND position >= ?`,
 	deletePagesByText: `DELETE FROM page WHERE text_id = ?`,
-	editPage: `UPDATE page SET content = ? WHERE text_id = ? AND number = ?`,
+	editPage: `UPDATE page SET content = ? WHERE text_id = ? AND position = ?`,
 	//#endregion
 
 	//#region Word
@@ -259,17 +259,17 @@ const queries: { [key: string]: string } = {
 			reading
 		FROM entry
 		WHERE word_id = ?
-		ORDER BY number ASC`,
+		ORDER BY position ASC`,
 	addEntry: `INSERT INTO entry (
 			word_id,
-			number,
+			position,
 			meaning,
 			reading
 		)
 		VALUES (?, ?, ?, ?)`,
 	addEntriesInBatch: `INSERT INTO entry (
 			word_id,
-			number,
+			position,
 			meaning,
 			reading
 		)

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -32,11 +32,13 @@ const queries: { [key: string]: string } = {
 		CONSTRAINT uq__text__language_id__title UNIQUE (language_id, title)
 	)`,
 	createPageTable: `CREATE TABLE IF NOT EXISTS page (
+		id INTEGER,
 		text_id INTEGER,
 		number INTEGER,
 		content TEXT NOT NULL,
-		CONSTRAINT pk__page__text_id__number PRIMARY KEY (text_id, number),
+		CONSTRAINT pk__page__id PRIMARY KEY (id),
 		CONSTRAINT fk__page__text_id FOREIGN KEY (text_id) REFERENCES text (id)
+		CONSTRAINT uq__page__text_id__number UNIQUE (text_id, number)
 	)`,
 	createWordTable: `CREATE TABLE IF NOT EXISTS word (
 		id INTEGER,

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -135,7 +135,7 @@ const queries: { [key: string]: string } = {
 	//#endregion
 
 	//#region Page
-	getAllPages: `SELECT
+	getPagesByText: `SELECT
 			text_id AS textId,
 			number,
 			content

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -162,7 +162,15 @@ const queries: { [key: string]: string } = {
 			content
 		)
 		VALUES (?, ?, ?)`,
+	addPagesInBatch: `INSERT INTO page (
+			text_id,
+			number,
+			content
+		)
+		VALUES %DYNAMIC%`,
 	deletePage: `DELETE FROM page WHERE text_id = ? AND number = ?`,
+	deletePagesInBatch: `DELETE FROM page WHERE text_id = ? AND number >= ?`,
+	deletePagesByText: `DELETE FROM page WHERE text_id = ?`,
 	editPage: `UPDATE page SET content = ? WHERE text_id = ? AND number = ?`,
 	//#endregion
 

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -147,8 +147,8 @@ router.patch(
 				req.body.numberOfPages,
 				req.body.content,
 				parseInt(req.params.textId),
-				req.body.datetimeOpened,
-				req.body.datetimeFinished,
+				req.body.timeOpened,
+				req.body.timeFinished,
 				req.body.progress
 			);
 			res.sendStatus(200);
@@ -248,8 +248,8 @@ router.post(
 				req.body.status,
 				req.body.entries,
 				req.body.notes,
-				req.body.datetimeAdded,
-				req.body.datetimeUpdated
+				req.body.timeAdded,
+				req.body.timeUpdated
 			);
 			res.sendStatus(200);
 		}
@@ -263,7 +263,7 @@ router.post(
 				req.body.languageId,
 				req.body.contents,
 				req.body.status,
-				req.body.datetimeAdded
+				req.body.timeAdded
 			);
 			res.sendStatus(200);
 		}
@@ -288,8 +288,8 @@ router.patch(
 				req.body.status,
 				req.body.entries,
 				req.body.notes,
-				req.body.datetimeAdded,
-				req.body.datetimeUpdated,
+				req.body.timeAdded,
+				req.body.timeUpdated,
 				parseInt(req.params.wordId)
 			);
 			res.sendStatus(200);

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -167,34 +167,34 @@ router.get(
 	)
 );
 router.get(
-	'/texts/:textId/pages/:pageId',
+	'/texts/:textId/pages/:pagePosition',
 	errorWrapper(
 		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json(await pagesController.getPage(parseInt(req.params.textId), parseInt(req.params.pageId)));
+			res.json(await pagesController.getPage(parseInt(req.params.textId), parseInt(req.params.pagePosition)));
 		}
 	)
 );
 router.get(
-	'/texts/:textId/pages/:pageId/words',
+	'/texts/:textId/pages/:pagePosition/words',
 	errorWrapper(
 		async (req: express.Request, res: express.Response): Promise<void> => {
 			res.json(
 				{
-					words: await pagesController.getWords(parseInt(req.params.textId), parseInt(req.params.pageId)),
+					words: await pagesController.getWords(parseInt(req.params.textId), parseInt(req.params.pagePosition)),
 				}
 			);
 		}
 	)
 );
 router.patch(
-	'/texts/:textId/pages/:pageId',
+	'/texts/:textId/pages/:pagePosition',
 	errorWrapper(
 		async (req: express.Request, res: express.Response): Promise<void> => {
 			await pagesController.editPage(
 				parseInt(req.params.textId),
 				req.body.index,
 				req.body.content,
-				parseInt(req.params.pageId)
+				parseInt(req.params.pagePosition)
 			);
 			res.sendStatus(200);
 		}

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -162,7 +162,7 @@ router.get(
 	'/texts/:textId/pages/',
 	errorWrapper(
 		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json({ pages: await pagesController.getAllPages(parseInt(req.params.textId)) });
+			res.json({ pages: await pagesController.getPagesByText(parseInt(req.params.textId)) });
 		}
 	)
 );

--- a/server/test.http
+++ b/server/test.http
@@ -82,8 +82,8 @@ Content-Type: application/json
 		}
 	],
 	"notes": "Test notes",
-	"datetimeAdded": "2021-01-01T00:00:00",
-	"datetimeUpdated": "2021-01-01T00:00:00"
+	"timeAdded": 1723645819,
+	"timeUpdated": 1723645819
 }
 
 ###
@@ -94,7 +94,7 @@ Content-Type: application/json
 	"languageId": 26,
 	"contents": ["y", "la", "que", "en"],
 	"status": 99,
-	"datetimeAdded": "2024-04-18T21:46:39"
+	"timeAdded": 1723646053
 }
 
 ###
@@ -112,7 +112,7 @@ Content-Type: application/json
 			"reading": "Updated reading"
 		}
 	],
-	"datetimeUpdated": "2021-01-05T00:00:00"
+	"timeUpdated": 1723646073
 }
 
 ###


### PR DESCRIPTION
This pull request proposes modifications related to the database to make it more robust and optimized.
- Primary keys are now preferably of type [INTEGER PRIMARY KEY](https://www.sqlite.org/lang_createtable.html#rowid).
- All constraints (unique keys, foreign keys and primary keys) are now named.
- Indexes have been created to enhance the performance of critical queries such as the `findWordsInBatch` query, which now uses both the `ix__word__lower_content__language_id` and `ix__word__language_id__token_count__content` indexes, as can be checked with the [EXPLAIN QUERY PLAN](https://www.sqlite.org/eqp.html) command.
- Entries are now stored in a separate `entry` table on the database, instead of being stored as serialized JSON.
- Some new queries have been created to optimize the addition and deletion of pages.
- The _item_ concept has been renamed to _token_ for better clarity.
- Unix time is now used instead of ISO datetimes to save up space.