### PR TITLE
Create `status_log` table and Statistics page, closes #3

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -13,6 +13,7 @@ import { EditText } from './pages/edit-text';
 import { Home } from './pages/home';
 import { Languages } from './pages/languages';
 import { ReadText } from './pages/read-text';
+import { Statistics } from './pages/statistics';
 import { Texts } from './pages/texts';
 
 const App = (): JSX.Element => {
@@ -27,6 +28,7 @@ const App = (): JSX.Element => {
 				<Route path="/languages" element={<Languages />} />
 				<Route path="/languages/add" element={<AddLanguage />} />
 				<Route path="/languages/edit/:id" element={<EditLanguage />} />
+				<Route path="/statistics" element={<Statistics />} />
 			</Routes>
 		</BrowserRouter>
 	);

--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -390,6 +390,13 @@ class BackendConnector
 		const word = await response.json();
 		return word;
 	}
+
+	async getWordsImprovedCount(languageId: number): Promise<number>
+	{
+		const response: Response = await fetch('/api/statistics/words-improved-count/' + languageId);
+		const wordsImprovedCount = (await response.json()).wordsImprovedCount;
+		return wordsImprovedCount;
+	}
 }
 
 const backendConnector: BackendConnector = new BackendConnector();

--- a/client/src/pages/home/home.tsx
+++ b/client/src/pages/home/home.tsx
@@ -67,6 +67,8 @@ const Home = (): JSX.Element => {
 			<Link to="/languages">Go to languages</Link>
 			<br />
 			<Link to="/texts">Go to texts</Link>
+			<br />
+			<Link to="/statistics">Go to statistics</Link>
 		</HelmetProvider>
 	);
 };

--- a/client/src/pages/statistics/index.ts
+++ b/client/src/pages/statistics/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+export * from './statistics';

--- a/client/src/pages/statistics/statistics.tsx
+++ b/client/src/pages/statistics/statistics.tsx
@@ -1,0 +1,55 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+import { Link, Outlet } from 'react-router-dom';
+
+import { Text } from '@common/types';
+import { backendConnector } from '../../backend-connector';
+import { Loading } from '../../components/loading';
+import { TextCard } from '../../components/text-card';
+
+const Statistics = (): JSX.Element => {
+	const [wordsImprovedCount, setWordsImprovedCount] = useState<number | null>(null);
+
+	let languageId: number | undefined = Number(document.cookie.split("=")[1]);
+	languageId = (isNaN(languageId) || languageId === 0) ? undefined : languageId;
+
+	useEffect(
+		(): void => {
+			if(languageId)
+			{
+				backendConnector.getWordsImprovedCount(languageId).then(
+					(count: number): void => {
+						setWordsImprovedCount(count);
+					}
+				);
+			}
+		},
+		[]
+	);
+
+	if (wordsImprovedCount == null)
+	{
+		return <Loading />;
+	}
+
+	return (
+		<HelmetProvider>
+			<Helmet>
+				<title>Irakur - Statistics</title>
+			</Helmet>
+			<h1>Irakur - Statistics</h1>
+			
+			In the last 24 hours, you have improved <strong>{wordsImprovedCount}</strong> word(s).
+
+			<Outlet />
+		</HelmetProvider>
+	);
+};
+
+export { Statistics };

--- a/server/src/controllers/statistics-controller.ts
+++ b/server/src/controllers/statistics-controller.ts
@@ -1,0 +1,22 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import { databaseManager } from "../database/database-manager";
+import { queries } from "../database/queries";
+
+class StatisticsController
+{
+	async getWordsImprovedCount(languageId: number): Promise<{wordsImprovedCount: number}>
+    {
+        return {
+            wordsImprovedCount: (await databaseManager.getFirstRow(
+                queries.getWordsImprovedCount, [languageId]
+            )).wordsImprovedCount
+        };
+    }
+}
+
+export { StatisticsController };

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -79,6 +79,11 @@ class DatabaseManager
 		await this.executeQuery(queries.createTextLanguageIdTitleIndex);
 		await this.executeQuery(queries.createWordLowerContentLanguageIdIndex);
 		await this.executeQuery(queries.createWordLanguageIdTokenCountContentIndex);
+
+		// Create triggers
+		await this.executeQuery(queries.createInsertStatusLogAfterInsertWordTrigger);
+		await this.executeQuery(queries.createInsertStatusLogAfterUpdateWordTrigger);
+		await this.executeQuery(queries.createDeleteStatusLogAfterDeleteWordTrigger);
 	}
 
 	executeQuery(query: string, parameters: any[] = []): Promise<any>

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -73,6 +73,7 @@ class DatabaseManager
 		await this.executeQuery(queries.createPageTable);
 		await this.executeQuery(queries.createWordTable);
 		await this.executeQuery(queries.createEntryTable);
+		await this.executeQuery(queries.createStatusLogTable);
 
 		// Create indexes
 		await this.executeQuery(queries.createTextLanguageIdTitleIndex);

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -63,6 +63,15 @@ const queries: { [key: string]: string } = {
 		CONSTRAINT fk__entry__word_id FOREIGN KEY (word_id) REFERENCES word (id),
 		CONSTRAINT uq__entry__word_id__position UNIQUE (word_id, position)
 	)`,
+	createStatusLogTable: `CREATE TABLE IF NOT EXISTS status_log (
+		id INTEGER,
+		word_id INTEGER NOT NULL,
+		status INTEGER NOT NULL,
+		time_updated INTEGER NOT NULL,
+		CONSTRAINT pk__status_log__id PRIMARY KEY (id),
+		CONSTRAINT fk__status_log__word_id FOREIGN KEY (word_id) REFERENCES word (id)
+		CONSTRAINT uq__status_log__word_id__time_updated UNIQUE (word_id, time_updated)
+	)`,
 	//#endregion
 
 	//#region Create indexes

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -89,6 +89,47 @@ const queries: { [key: string]: string } = {
 		)`,
 	//#endregion
 
+	//#region Create triggers
+	createInsertStatusLogAfterInsertWordTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__status_log__after__insert__word
+		AFTER INSERT ON word
+		BEGIN
+			INSERT INTO status_log (
+				word_id,
+				status,
+				time_updated
+			)
+			VALUES (
+				NEW.id,
+				NEW.status,
+				NEW.time_updated
+			);
+		END`,
+	createInsertStatusLogAfterUpdateWordTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__status_log__after__update__word
+		AFTER UPDATE ON word
+		WHEN OLD.status != NEW.status
+		BEGIN
+			INSERT INTO status_log (
+				word_id,
+				status,
+				time_updated
+			)
+			VALUES (
+				NEW.id,
+				NEW.status,
+				NEW.time_updated
+			);
+		END`,
+	createDeleteStatusLogAfterDeleteWordTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__delete__status_log__after__delete__word
+		AFTER DELETE ON word
+		BEGIN
+			DELETE FROM status_log
+			WHERE word_id = OLD.id;
+		END`,
+	//#endregion
+
 	//#region Language
 	getAllLanguages: `SELECT
 			id,

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -327,6 +327,36 @@ const queries: { [key: string]: string } = {
 	deleteEntriesByWord: `DELETE FROM entry WHERE word_id = ?`,
 	//#endregion
 
+	//#region Status Log
+	getWordsImprovedCount: `WITH first_status_of_day AS (
+			SELECT
+				word_id,
+				status AS first_status,
+				MIN(time_updated) AS first_time_updated
+			FROM status_log
+			WHERE time_updated >= strftime('%s', 'now') - 86400
+			GROUP BY word_id
+		),
+		last_status_of_day AS (
+			SELECT
+				word_id,
+				status AS last_status,
+				MAX(time_updated) AS last_time_updated
+			FROM status_log
+			WHERE time_updated >= strftime('%s', 'now') - 86400
+			GROUP BY word_id
+		)
+		SELECT
+			COUNT(*) AS wordsImprovedCount
+		FROM first_status_of_day fs
+		JOIN last_status_of_day ls
+		ON fs.word_id = ls.word_id
+		JOIN word
+		ON word.id = ls.word_id
+		WHERE last_status > first_status
+			AND word.language_id = ?`,
+	//#endregion
+
 	//#region Utils
 	getLastInsertId: `SELECT last_insert_rowid() AS id`,
 	//#endregion

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -8,6 +8,7 @@ import express from 'express';
 
 import { LanguagesController } from '../controllers/languages-controller';
 import { PagesController } from '../controllers/pages-controller';
+import { StatisticsController } from '../controllers/statistics-controller';
 import { TextsController } from '../controllers/texts-controller';
 import { WordsController } from '../controllers/words-controller';
 
@@ -15,6 +16,7 @@ const languagesController = new LanguagesController();
 const textsController = new TextsController();
 const pagesController = new PagesController();
 const wordsController = new WordsController();
+const statisticsController = new StatisticsController();
 
 const router = express.Router();
 
@@ -296,6 +298,17 @@ router.patch(
 		}
 	)
 );
+//#endregion
+
+//#region Statistics
+router.get(
+	'/statistics/words-improved-count/:languageId',
+	errorWrapper(
+		async (req: express.Request, res: express.Response): Promise<void> => {
+			res.json(await statisticsController.getWordsImprovedCount(parseInt(req.params.languageId)));
+		}
+	)
+)
 //#endregion
 
 export { router };

--- a/server/test.http
+++ b/server/test.http
@@ -117,3 +117,6 @@ Content-Type: application/json
 
 ###
 DELETE http://localhost:5000/api/words/1
+
+###
+GET http://localhost:5000/api/statistics/words-improved-count/1


### PR DESCRIPTION
A new table named `status_log` has been created in the database. This table is handled by three triggers that listen to intertions, updates and deletions on the `word` table. Whenever a word is created or its status changes, a new row is inserted into the `status_log` table. Likewise, whenever a word is deleted, so are the `status_log` rows that linked to it.

The main purpose of this table is to generate detailed statistics of the user's progress. Therefore, a Statistics page has been created on the front end, as well as a Statistics controller on the back end. These have, for the moment, a provisional functionality, and pretty much only serve as a proof of concept. The actual Statistics queries will be developed once the GUI has been decided.