### PR TITLE
Multiple profile support

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -22,7 +22,7 @@ const App = (): JSX.Element => {
 	return (
 		<BrowserRouter>
 			<Routes>
-				<Route path="/" element={<Home />} />
+				<Route path="/" element={<Profiles />} />
 				<Route path="/home" element={<Home />} />
 				<Route path="/texts" element={<Texts />} />
 				<Route path="/texts/add" element={<AddText />} />

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -15,6 +15,7 @@ import { Home } from './pages/home';
 import { Languages } from './pages/languages';
 import { Profiles } from './pages/profiles';
 import { ReadText } from './pages/read-text';
+import { Start } from './pages/start';
 import { Statistics } from './pages/statistics';
 import { Texts } from './pages/texts';
 
@@ -22,7 +23,7 @@ const App = (): JSX.Element => {
 	return (
 		<BrowserRouter>
 			<Routes>
-				<Route path="/" element={<Profiles />} />
+				<Route path="/" element={<Start />} />
 				<Route path="/home" element={<Home />} />
 				<Route path="/texts" element={<Texts />} />
 				<Route path="/texts/add" element={<AddText />} />

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -22,7 +22,7 @@ const App = (): JSX.Element => {
 	return (
 		<BrowserRouter>
 			<Routes>
-				<Route path="/" element={<Profiles />} />
+				<Route path="/" element={<Home />} />
 				<Route path="/home" element={<Home />} />
 				<Route path="/texts" element={<Texts />} />
 				<Route path="/texts/add" element={<AddText />} />

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -12,6 +12,7 @@ import { EditLanguage } from './pages/edit-language';
 import { EditText } from './pages/edit-text';
 import { Home } from './pages/home';
 import { Languages } from './pages/languages';
+import { Profiles } from './pages/profiles';
 import { ReadText } from './pages/read-text';
 import { Statistics } from './pages/statistics';
 import { Texts } from './pages/texts';
@@ -20,7 +21,8 @@ const App = (): JSX.Element => {
 	return (
 		<BrowserRouter>
 			<Routes>
-				<Route path="/" element={<Home />} />
+				<Route path="/" element={<Profiles />} />
+				<Route path="/home" element={<Home />} />
 				<Route path="/texts" element={<Texts />} />
 				<Route path="/texts/add" element={<AddText />} />
 				<Route path="/texts/edit/:id" element={<EditText />} />

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -7,6 +7,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import { AddLanguage } from './pages/add-language';
+import { AddProfile } from './pages/add-profile';
 import { AddText } from './pages/add-text';
 import { EditLanguage } from './pages/edit-language';
 import { EditText } from './pages/edit-text';
@@ -30,6 +31,8 @@ const App = (): JSX.Element => {
 				<Route path="/languages" element={<Languages />} />
 				<Route path="/languages/add" element={<AddLanguage />} />
 				<Route path="/languages/edit/:id" element={<EditLanguage />} />
+				<Route path="/profiles" element={<Profiles />} />
+				<Route path="/profiles/add" element={<AddProfile />} />
 				<Route path="/statistics" element={<Statistics />} />
 			</Routes>
 		</BrowserRouter>

--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -397,6 +397,42 @@ class BackendConnector
 		const wordsImprovedCount = (await response.json()).wordsImprovedCount;
 		return wordsImprovedCount;
 	}
+
+	async getProfiles(): Promise<string[]>
+	{
+		const response: Response = await fetch('/api/profiles');
+		const profiles = (await response.json()).profiles;
+		return profiles;
+	}
+
+	async setActiveProfile(profileName: string): Promise<boolean>
+	{
+		const response: Response = await fetch(
+			'/api/profiles/active',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(
+					{
+						profileName,
+					}
+				),
+			}
+		);
+
+		if (!response.ok)
+		{
+			console.error('Failed to add words');
+		}
+		else
+		{
+			console.log('Words added');
+		}
+
+		return response.ok;
+	}
 }
 
 const backendConnector: BackendConnector = new BackendConnector();

--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -424,11 +424,40 @@ class BackendConnector
 
 		if (!response.ok)
 		{
-			console.error('Failed to add words');
+			console.error('Failed to set active profile');
 		}
 		else
 		{
-			console.log('Words added');
+			console.log('Active profile set');
+		}
+
+		return response.ok;
+	}
+
+	async addProfile(profileName: string): Promise<boolean>
+	{
+		const response: Response = await fetch(
+			'/api/profiles',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(
+					{
+						profileName
+					}
+				),
+			}
+		);
+		
+		if (!response.ok)
+		{
+			console.error('Failed to add profile');
+		}
+		else
+		{
+			console.log('Profile added');
 		}
 
 		return response.ok;

--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -405,6 +405,17 @@ class BackendConnector
 		return profiles;
 	}
 
+	async getActiveProfile(): Promise<string | null>
+	{
+		const response: Response = await fetch('/api/profiles/active');
+		if (!response.ok)
+		{
+			return null;
+		}
+		const profileName = (await response.json()).profileName;
+		return profileName;
+	}
+
 	async setActiveProfile(profileName: string): Promise<boolean>
 	{
 		const response: Response = await fetch(

--- a/client/src/pages/add-profile/add-profile.tsx
+++ b/client/src/pages/add-profile/add-profile.tsx
@@ -1,0 +1,56 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import React, { useState } from 'react';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+
+import { backendConnector } from '../../backend-connector';
+
+const AddProfile = (): JSX.Element => {
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+		event.preventDefault();
+
+		setIsSubmitting(true);
+
+		if (event.target === null)
+		{
+			return;
+		}
+
+		const form = new FormData(event.target as HTMLFormElement);
+
+		const wasAdded: boolean = await backendConnector.addProfile(
+			form.get('name') as string
+		);
+
+		if (wasAdded)
+		{
+			window.location.href = '/profiles';
+		}
+
+		setIsSubmitting(false);
+	};
+
+	return (
+		<HelmetProvider>
+			<Helmet>
+				<title>Irakur - Add profile</title>
+			</Helmet>
+			<h1>Irakur - Add profile</h1>
+			<form method="post" onSubmit={handleSubmit}>
+				<label htmlFor="name">Name</label>
+				<input type="text" name="name" id="name" />
+				<br />
+
+				<button type="submit" disabled={isSubmitting}>Add</button>
+			</form>
+		</HelmetProvider>
+	);
+};
+
+export { AddProfile };

--- a/client/src/pages/add-profile/index.ts
+++ b/client/src/pages/add-profile/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+export * from './add-profile';

--- a/client/src/pages/home/home.tsx
+++ b/client/src/pages/home/home.tsx
@@ -53,6 +53,8 @@ const Home = (): JSX.Element => {
 				<title>Irakur - Home</title>
 			</Helmet>
 			<h1>Irakur - Home</h1>
+			<Link to="/profiles">Choose profile</Link>
+			<br />
 			<select name="activeLanguage" id="activeLanguage" onChange={handleLanguageChange}>
 				<option value="">Select language</option>
 				{

--- a/client/src/pages/home/home.tsx
+++ b/client/src/pages/home/home.tsx
@@ -53,8 +53,6 @@ const Home = (): JSX.Element => {
 				<title>Irakur - Home</title>
 			</Helmet>
 			<h1>Irakur - Home</h1>
-			<Link to="/profiles">Choose profile</Link>
-			<br />
 			<select name="activeLanguage" id="activeLanguage" onChange={handleLanguageChange}>
 				<option value="">Select language</option>
 				{

--- a/client/src/pages/profiles/index.ts
+++ b/client/src/pages/profiles/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+export * from './profiles';

--- a/client/src/pages/profiles/profiles.tsx
+++ b/client/src/pages/profiles/profiles.tsx
@@ -6,6 +6,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
 
 import { backendConnector } from '../../backend-connector';
 import { Loading } from '../../components/loading';
@@ -74,6 +75,7 @@ const Profiles = (): JSX.Element => {
 				<title>Irakur - Profiles</title>
 			</Helmet>
 			<h1>Irakur - Profiles</h1>
+			<Link to="/profiles/add">Add profile</Link>
 			<form method="post" onSubmit={handleSubmit}>
 				<select name="activeProfile" id="activeProfile" onChange={handleProfileChange}>
 					<option value="">Select profile</option>

--- a/client/src/pages/profiles/profiles.tsx
+++ b/client/src/pages/profiles/profiles.tsx
@@ -1,0 +1,94 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+
+import { backendConnector } from '../../backend-connector';
+import { Loading } from '../../components/loading';
+
+const Profiles = (): JSX.Element => {
+	const [profiles, setProfiles] = useState<string[] | null>(null);
+	const [activeProfile, setActiveProfile] = useState<string | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+	const handleProfileChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+		if (event.target === null)
+		{
+			return;
+		}
+
+		if (event.target.value === '')
+		{
+			setActiveProfile(null);
+		}
+		else
+		{
+			setActiveProfile(event.target.value);
+		}
+	};
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+		event.preventDefault();
+
+		setIsSubmitting(true);
+
+		if (event.target === null)
+		{
+			setIsSubmitting(false);
+			return;
+		}
+
+		const wasSet: boolean = (await backendConnector.setActiveProfile(activeProfile as string));
+
+		if (wasSet)
+		{
+			window.location.href = '/home';
+		}
+		
+		setIsSubmitting(false);
+	};
+
+	useEffect(
+		(): void => {
+			backendConnector.getProfiles().then(
+				(profiles: string[]): void => {
+					setProfiles(profiles);
+				}
+			);
+		},
+		[]
+	);
+
+	if (!profiles)
+	{
+		return <Loading />;
+	}
+
+	return (
+		<HelmetProvider>
+			<Helmet>
+				<title>Irakur - Profiles</title>
+			</Helmet>
+			<h1>Irakur - Profiles</h1>
+			<form method="post" onSubmit={handleSubmit}>
+				<select name="activeProfile" id="activeProfile" onChange={handleProfileChange}>
+					<option value="">Select profile</option>
+					{
+						profiles.map(
+							(profiles: string) =>(
+								<option key={profiles} value={profiles}>{profiles}</option>
+							)
+						)
+					}
+				</select>
+				<button type="submit" disabled={isSubmitting || !activeProfile}>Proceed</button>
+			</form>
+		</HelmetProvider>
+	);
+};
+
+export { Profiles };

--- a/client/src/pages/start/index.ts
+++ b/client/src/pages/start/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+export * from './start';

--- a/client/src/pages/start/start.tsx
+++ b/client/src/pages/start/start.tsx
@@ -1,0 +1,34 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import { useEffect } from 'react';
+
+import { backendConnector } from '../../backend-connector';
+import { Loading } from '../../components/loading';
+
+const Start = (): JSX.Element => {
+	useEffect(
+		(): void => {
+			backendConnector.getActiveProfile().then(
+				(profileName: string | null): void => {
+					if (profileName === null)
+					{
+						window.location.href = '/profiles'
+					}
+					else
+					{
+						window.location.href = '/home'
+					}
+				}
+			);
+		},
+		[]
+	);
+
+	return <Loading />;
+};
+
+export { Start };

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -7,7 +7,7 @@
 const getUnixTime = (): number =>
 {
 	return Math.floor(Date.now() / 1000);
-}
+};
 
 const tokenizeString = (str: string): string[] =>
 {
@@ -15,6 +15,18 @@ const tokenizeString = (str: string): string[] =>
 		.filter((sentence: string) => sentence !== '');
 
 	return tokens;
-}
+};
 
-export { getUnixTime, tokenizeString };
+const getEnvironmentVariable = (name: string): string =>
+{
+	if (process.env[name] !== undefined)
+	{
+		return process.env[name] as string;
+	}
+	else
+	{
+		throw new Error(`Environment variable ${name} not found`);
+	}
+};
+
+export { getEnvironmentVariable, getUnixTime, tokenizeString };

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -4,6 +4,8 @@
  * Licensed under version 3 of the GNU Affero General Public License
  */
 
+declare var process: any;
+
 const getUnixTime = (): number =>
 {
 	return Math.floor(Date.now() / 1000);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -7,7 +7,12 @@
 import cors from 'cors';
 import express from 'express';
 import morgan from 'morgan';
+import os from 'os';
 import path from 'path';
+
+process.env.DATA_FOLDER_PATH = (os.platform() === 'win32')
+	? path.join(os.homedir(), 'AppData', 'Local', 'irakur', 'data')
+	: path.join(os.homedir(), '.config', 'irakur', 'data')
 
 import { router } from './routers/api-router';
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,8 +11,8 @@ import os from 'os';
 import path from 'path';
 
 process.env.DATA_FOLDER_PATH = (os.platform() === 'win32')
-	? path.join(os.homedir(), 'AppData', 'Local', 'irakur', 'data')
-	: path.join(os.homedir(), '.config', 'irakur', 'data')
+	? path.join(os.homedir(), 'AppData', 'Local', 'irakur')
+	: path.join(os.homedir(), '.config', 'irakur')
 
 import { router } from './routers/api-router';
 

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -62,6 +62,16 @@ class DatabaseManager
 		return this.database;
 	}
 
+	closeDatabase(): void
+	{
+		if (this.database === null)
+		{
+			return;
+		}
+		this.database.close();
+		this.database = null;
+	}
+
 	async initializeDatabase(): Promise<void>
 	{
 		// Create tables

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -5,10 +5,10 @@
  */
 
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import sqlite3 from 'sqlite3';
 
+import { getEnvironmentVariable } from '../../../common/utils';
 import { queries } from './queries';
 
 class DatabaseManager
@@ -137,15 +137,8 @@ class DatabaseManager
 	}
 }
 
-let dataFolderPath: string;
-if (os.platform() === 'win32') {
-    dataFolderPath = path.join(os.homedir(), 'AppData', 'Roaming', 'irakur');
-} else {
-    dataFolderPath = path.join(os.homedir(), '.config', 'irakur');
-}
-
 const databaseFileName: string = 'database.db';
 
-const databaseManager = new DatabaseManager(dataFolderPath, databaseFileName);
+const databaseManager = new DatabaseManager(getEnvironmentVariable('DATA_FOLDER_PATH'), databaseFileName);
 
 export { databaseManager };

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -5,6 +5,7 @@
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import sqlite3 from 'sqlite3';
 
@@ -28,7 +29,7 @@ class DatabaseManager
 
 		if (!fs.existsSync(dataFolderPath))
 		{
-			fs.mkdirSync(dataFolderPath);
+			fs.mkdirSync(dataFolderPath, { recursive: true });
 		}
 
 		if (!fs.existsSync(databaseFilePath))
@@ -54,7 +55,7 @@ class DatabaseManager
 				}
 				else
 				{
-					console.log('Connected to the Irakur database.');
+					console.log('Connected to ' + databaseFilePath);
 				}
 			}
 		);
@@ -136,5 +137,15 @@ class DatabaseManager
 	}
 }
 
-const databaseManager = new DatabaseManager('data', 'irakur.db');
+let dataFolderPath: string;
+if (os.platform() === 'win32') {
+    dataFolderPath = path.join(os.homedir(), 'AppData', 'Roaming', 'irakur');
+} else {
+    dataFolderPath = path.join(os.homedir(), '.config', 'irakur');
+}
+
+const databaseFileName: string = 'database.db';
+
+const databaseManager = new DatabaseManager(dataFolderPath, databaseFileName);
+
 export { databaseManager };

--- a/server/src/managers/data-folder-manager.ts
+++ b/server/src/managers/data-folder-manager.ts
@@ -1,0 +1,94 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { getEnvironmentVariable } from '../../../common/utils';
+
+import { databaseManager } from '../database/database-manager';
+
+class DataFolderManager
+{
+	private static instance: DataFolderManager;
+
+	private profileNames: string[] = [];
+	
+	constructor()
+	{
+		if (DataFolderManager.instance)
+		{
+			return DataFolderManager.instance;
+		}
+		
+		this.readDataFolder();
+
+		if (this.profileNames.length === 0)
+		{
+			this.createProfile('User 1');
+			this.setActiveProfile('User 1');
+		}
+		else if (this.profileNames.length === 1)
+		{
+			this.setActiveProfile(this.profileNames[0]);
+		}
+
+		DataFolderManager.instance = this;
+	}
+
+	readDataFolder(): void
+	{
+		const dataFolderPath: string = getEnvironmentVariable('DATA_FOLDER_PATH');
+		if (!fs.existsSync(dataFolderPath))
+		{
+			fs.mkdirSync(dataFolderPath, { recursive: true });
+		}
+
+		console.log('Data folder path: ' + dataFolderPath);
+
+		// Find an array of folders in the data folder that start with 'profile-'
+		this.profileNames = fs.readdirSync(dataFolderPath, { withFileTypes: true })
+			.filter((dirent: fs.Dirent) => (dirent.name.startsWith('profile-') && dirent.isDirectory()))
+			.map((dirent: fs.Dirent) => dirent.name)
+			.map((folder: string) => folder.substring('profile-'.length));
+	}
+
+	createProfile(name: string): void
+	{
+		const profilePath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + name);
+		if (fs.existsSync(profilePath))
+		{
+			throw new Error('Profile ' + name + ' already exists');
+		}
+
+		fs.mkdirSync(profilePath);
+
+		this.profileNames.push(name);
+	}
+
+	getProfileNames(): string[]
+	{
+		return this.profileNames;
+	}
+
+	renameProfile(oldName: string, newName: string): void
+	{
+		const oldPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + oldName);
+		const newPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + newName);
+		fs.renameSync(oldPath, newPath);
+	}
+
+	setActiveProfile(profileName: string): void
+	{
+		databaseManager.openDatabase(
+			path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + profileName, 'database.db')
+		);
+	}
+}
+
+const dataFolderManager: DataFolderManager = new DataFolderManager();
+
+export { dataFolderManager };

--- a/server/src/managers/data-folder-manager.ts
+++ b/server/src/managers/data-folder-manager.ts
@@ -85,6 +85,8 @@ class DataFolderManager
 		const oldPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profiles', oldName);
 		const newPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profiles', newName);
 		fs.renameSync(oldPath, newPath);
+
+		this.profileNames = this.profileNames.map((name: string) => name === oldName ? newName : name);
 	}
 
 	getActiveProfile(): string | null

--- a/server/src/managers/data-folder-manager.ts
+++ b/server/src/managers/data-folder-manager.ts
@@ -102,6 +102,10 @@ class DataFolderManager
 			this.activeProfile = null;
 			return;
 		}
+		else if (!this.profileNames.includes(profileName))
+		{
+			throw new Error('Profile ' + profileName + ' does not exist');
+		}
 		this.activeProfile = profileName;
 		databaseManager.openDatabase(
 			path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profiles', profileName, 'database.db')

--- a/server/src/managers/data-folder-manager.ts
+++ b/server/src/managers/data-folder-manager.ts
@@ -51,16 +51,20 @@ class DataFolderManager
 
 		console.log('Data folder path: ' + dataFolderPath);
 
-		// Find an array of folders in the data folder that start with 'profile-'
-		this.profileNames = fs.readdirSync(dataFolderPath, { withFileTypes: true })
-			.filter((dirent: fs.Dirent) => (dirent.name.startsWith('profile-') && dirent.isDirectory()))
-			.map((dirent: fs.Dirent) => dirent.name)
-			.map((folder: string) => folder.substring('profile-'.length));
+		const profilesFolderPath: string = path.join(dataFolderPath, 'profiles');
+		if (!fs.existsSync(profilesFolderPath))
+		{
+			fs.mkdirSync(profilesFolderPath, { recursive: true });
+		}
+
+		this.profileNames = fs.readdirSync(profilesFolderPath, { withFileTypes: true })
+			.filter((dirent: fs.Dirent) => dirent.isDirectory())
+			.map((dirent: fs.Dirent) => dirent.name);
 	}
 
 	createProfile(name: string): void
 	{
-		const profilePath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + name);
+		const profilePath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profiles', name);
 		if (fs.existsSync(profilePath))
 		{
 			throw new Error('Profile ' + name + ' already exists');
@@ -78,8 +82,8 @@ class DataFolderManager
 
 	renameProfile(oldName: string, newName: string): void
 	{
-		const oldPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + oldName);
-		const newPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + newName);
+		const oldPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profiles', oldName);
+		const newPath: string = path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profiles', newName);
 		fs.renameSync(oldPath, newPath);
 	}
 
@@ -92,7 +96,7 @@ class DataFolderManager
 	{
 		this.activeProfile = profileName;
 		databaseManager.openDatabase(
-			path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + profileName, 'database.db')
+			path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profiles', profileName, 'database.db')
 		);
 	}
 }

--- a/server/src/managers/data-folder-manager.ts
+++ b/server/src/managers/data-folder-manager.ts
@@ -16,6 +16,8 @@ class DataFolderManager
 	private static instance: DataFolderManager;
 
 	private profileNames: string[] = [];
+
+	private activeProfile: string = '';
 	
 	constructor()
 	{
@@ -81,8 +83,14 @@ class DataFolderManager
 		fs.renameSync(oldPath, newPath);
 	}
 
+	getActiveProfile(): string
+	{
+		return this.activeProfile;
+	}
+
 	setActiveProfile(profileName: string): void
 	{
+		this.activeProfile = profileName;
 		databaseManager.openDatabase(
 			path.join(getEnvironmentVariable('DATA_FOLDER_PATH'), 'profile-' + profileName, 'database.db')
 		);

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -6,6 +6,7 @@
 
 import express from 'express';
 
+import { dataFolderManager } from '../managers/data-folder-manager';
 import { LanguagesController } from '../controllers/languages-controller';
 import { PagesController } from '../controllers/pages-controller';
 import { StatisticsController } from '../controllers/statistics-controller';
@@ -309,6 +310,35 @@ router.get(
 		}
 	)
 )
+//#endregion
+
+//#region Profiles
+router.get(
+	'/profiles/',
+	errorWrapper(
+		(req: express.Request, res: express.Response): void => {
+			res.json({ profiles: dataFolderManager.getProfileNames() });
+		}
+	)
+)
+router.post(
+	'/profiles/active',
+	errorWrapper(
+		(req: express.Request, res: express.Response): void => {
+			dataFolderManager.setActiveProfile(req.body.profileName);
+			res.sendStatus(200);
+		}
+	)
+)
+router.post(
+	'/profiles/',
+	errorWrapper(
+		(req: express.Request, res: express.Response): void => {
+			dataFolderManager.createProfile(req.body.profileName);
+			res.sendStatus(200);
+		}
+	)
+);
 //#endregion
 
 export { router };

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -356,6 +356,24 @@ router.post(
 		}
 	)
 );
+router.delete(
+	'/profiles/:profileName',
+	errorWrapper(
+		(req: express.Request, res: express.Response): void => {
+			dataFolderManager.deleteProfile(req.params.profileName);
+			res.sendStatus(200);
+		}
+	)
+);
+router.patch(
+	'/profiles/:profileName',
+	errorWrapper(
+		(req: express.Request, res: express.Response): void => {
+			dataFolderManager.renameProfile(req.params.profileName, req.body.newProfileName);
+			res.sendStatus(200);
+		}
+	)
+)
 //#endregion
 
 export { router };

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -309,7 +309,7 @@ router.get(
 			res.json(await statisticsController.getWordsImprovedCount(parseInt(req.params.languageId)));
 		}
 	)
-)
+);
 //#endregion
 
 //#region Profiles
@@ -320,21 +320,38 @@ router.get(
 			res.json({ profiles: dataFolderManager.getProfileNames() });
 		}
 	)
-)
-router.post(
+);
+router.get(
 	'/profiles/active',
 	errorWrapper(
 		(req: express.Request, res: express.Response): void => {
-			dataFolderManager.setActiveProfile(req.body.profileName);
-			res.sendStatus(200);
+			const profileName: string | null = dataFolderManager.getActiveProfile();
+
+			if (profileName)
+			{
+				res.json({ profileName });
+			}
+			else
+			{
+				res.sendStatus(404);
+			}
 		}
 	)
-)
+);
 router.post(
 	'/profiles/',
 	errorWrapper(
 		(req: express.Request, res: express.Response): void => {
 			dataFolderManager.createProfile(req.body.profileName);
+			res.sendStatus(200);
+		}
+	)
+);
+router.post(
+	'/profiles/active',
+	errorWrapper(
+		(req: express.Request, res: express.Response): void => {
+			dataFolderManager.setActiveProfile(req.body.profileName);
 			res.sendStatus(200);
 		}
 	)

--- a/server/test.http
+++ b/server/test.http
@@ -120,3 +120,22 @@ DELETE http://localhost:5000/api/words/1
 
 ###
 GET http://localhost:5000/api/statistics/words-improved-count/1
+
+###
+GET http://localhost:5000/api/profiles
+
+###
+POST http://localhost:5000/api/profiles
+Content-Type: application/json
+
+{
+	"profileName": "User 2"
+}
+
+###
+POST http://localhost:5000/api/profiles/active
+Content-Type: application/json
+
+{
+	"profileName": "User 2"
+}

--- a/server/test.http
+++ b/server/test.http
@@ -133,6 +133,9 @@ Content-Type: application/json
 }
 
 ###
+GET http://localhost:5000/api/profiles/active
+
+###
 POST http://localhost:5000/api/profiles/active
 Content-Type: application/json
 

--- a/server/test.http
+++ b/server/test.http
@@ -142,3 +142,14 @@ Content-Type: application/json
 {
 	"profileName": "User 2"
 }
+
+###
+DELETE http://localhost:5000/api/profiles/User 2
+
+###
+PATCH http://localhost:5000/api/profiles/User 2
+Content-Type: application/json
+
+{
+	"newProfileName": "User 3"
+}


### PR DESCRIPTION
This Pull Request aims to implement support for multiple profiles.

- User data is now stored on data paths specific to the OS in use (`~\Appdata\Roaming\irakur` on Windows, `~/.config/irakur` otherwise).
- Inside this data folder, there exists (and is created otherwise) a folder named `profiles`, which contains a different folder for each of the profiles. The profile name is given by the folder's name. Each profile has its own unique `database.db` file.
- Right now, the Database Manager in the server can have a single database open at a time. The profile whose database is open is referred to as 'active profile'.
- If no profile exists, a profile named 'User 1' will be created and set as active profile automatically. If a single profile exists, it will be set as active profile automatically. If multiple profiles exist, manual setting of the active profile is required before using the Database Manager.
- The server provides API routes to get a list of profiles, append new profiles to the list, get and set the active profile, and delete or modify the name of profiles.
- The client provides an interface to set an active profile, as well as to create new profiles. Deleting and renaming will not be implemented until the design is worked on.