### PR TITLE
Migrate from `sqlite3` to `better-sqlite3`

### DIFF
--- a/docs/CODINGSTYLE.md
+++ b/docs/CODINGSTYLE.md
@@ -97,7 +97,7 @@ if (!response.ok) {
 if (!response.ok)
 	...
 
-await databaseManager.executeQuery(queries.deleteWord,
+await databaseManager.runQuery(queries.deleteWord,
 	[wordId]
 );
 
@@ -107,7 +107,7 @@ if (!response.ok)
 	...
 }
 
-await databaseManager.executeQuery(
+await databaseManager.runQuery(
 	queries.deleteWord,
 	[wordId]
 );

--- a/docs/CODINGSTYLE.md
+++ b/docs/CODINGSTYLE.md
@@ -97,7 +97,7 @@ if (!response.ok) {
 if (!response.ok)
 	...
 
-await databaseManager.runQuery(queries.deleteWord,
+databaseManager.runQuery(queries.deleteWord,
 	[wordId]
 );
 
@@ -107,7 +107,7 @@ if (!response.ok)
 	...
 }
 
-await databaseManager.runQuery(
+databaseManager.runQuery(
 	queries.deleteWord,
 	[wordId]
 );

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,14 +9,15 @@
 			"version": "0.0.1",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
+				"@types/better-sqlite3": "^7.6.11",
 				"@types/cors": "^2.8.17",
 				"@types/express": "^4.17.21",
 				"@types/morgan": "^1.9.9",
+				"better-sqlite3": "^11.2.1",
 				"cors": "^2.8.5",
 				"ejs": "^3.1.9",
 				"express": "^4.18.2",
 				"morgan": "^1.10.0",
-				"sqlite3": "^5.1.6",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.3.3"
 			},
@@ -35,12 +36,6 @@
 			"engines": {
 				"node": ">=12"
 			}
-		},
-		"node_modules/@gar/promisify": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-			"optional": true
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.1",
@@ -64,72 +59,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"node_modules/@mapbox/node-pre-gyp": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-			"integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-			"dependencies": {
-				"detect-libc": "^2.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"make-dir": "^3.1.0",
-				"node-fetch": "^2.6.7",
-				"nopt": "^5.0.0",
-				"npmlog": "^5.0.1",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"node-pre-gyp": "bin/node-pre-gyp"
-			}
-		},
-		"node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-			"dependencies": {
-				"abbrev": "1"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@npmcli/fs": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-			"integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-			"optional": true,
-			"dependencies": {
-				"@gar/promisify": "^1.0.1",
-				"semver": "^7.3.5"
-			}
-		},
-		"node_modules/@npmcli/move-file": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-			"integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-			"deprecated": "This functionality has been moved to @npmcli/fs",
-			"optional": true,
-			"dependencies": {
-				"mkdirp": "^1.0.4",
-				"rimraf": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@tootallnate/once": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"optional": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/@tsconfig/node10": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -149,6 +78,14 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
 			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+		},
+		"node_modules/@types/better-sqlite3": {
+			"version": "7.6.11",
+			"resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.11.tgz",
+			"integrity": "sha512-i8KcD3PgGtGBLl3+mMYA8PdKkButvPyARxA7IQAd6qeslht13qxb1zzO8dRCtE7U3IoJS782zDBAeoKiM695kg==",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/body-parser": {
 			"version": "1.19.5",
@@ -255,7 +192,8 @@
 		"node_modules/abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -288,71 +226,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/agent-base/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/agent-base/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"node_modules/agentkeepalive": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-			"integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
-			"optional": true,
-			"dependencies": {
-				"humanize-ms": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
-			}
-		},
-		"node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"optional": true,
-			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -380,23 +253,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/aproba": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
-		},
-		"node_modules/are-we-there-yet": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -417,6 +273,25 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/basic-auth": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -433,6 +308,16 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"node_modules/better-sqlite3": {
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.2.1.tgz",
+			"integrity": "sha512-Xbt1d68wQnUuFIEVsbt6V+RG30zwgbtCGQ4QOcXVrOH0FE4eHk64FWZ9NUfRHS4/x1PXqwz/+KOrnXD7f0WieA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.1"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -440,6 +325,24 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
 			}
 		},
 		"node_modules/body-parser": {
@@ -488,6 +391,29 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -495,35 +421,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/cacache": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-			"integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-			"optional": true,
-			"dependencies": {
-				"@npmcli/fs": "^1.0.0",
-				"@npmcli/move-file": "^1.0.1",
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"glob": "^7.1.4",
-				"infer-owner": "^1.0.4",
-				"lru-cache": "^6.0.0",
-				"minipass": "^3.1.1",
-				"minipass-collect": "^1.0.2",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.2",
-				"mkdirp": "^1.0.3",
-				"p-map": "^4.0.0",
-				"promise-inflight": "^1.0.1",
-				"rimraf": "^3.0.2",
-				"ssri": "^8.0.1",
-				"tar": "^6.0.2",
-				"unique-filename": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 10"
 			}
 		},
 		"node_modules/call-bind": {
@@ -588,21 +485,9 @@
 			}
 		},
 		"node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"optional": true,
-			"engines": {
-				"node": ">=6"
-			}
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
@@ -620,23 +505,10 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"node_modules/color-support": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"bin": {
-				"color-support": "bin.js"
-			}
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-		},
-		"node_modules/console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
@@ -697,6 +569,28 @@
 				"ms": "2.0.0"
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -713,11 +607,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
@@ -737,9 +626,9 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
 			"engines": {
 				"node": ">=8"
 			}
@@ -772,11 +661,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -785,41 +669,13 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"optional": true,
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dependencies": {
-				"iconv-lite": "^0.6.2"
+				"once": "^1.4.0"
 			}
-		},
-		"node_modules/encoding/node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"optional": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/env-paths": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"optional": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/err-code": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-			"optional": true
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.0",
@@ -853,6 +709,14 @@
 			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/express": {
@@ -896,6 +760,11 @@
 			"engines": {
 				"node": ">= 0.10.0"
 			}
+		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"node_modules/filelist": {
 			"version": "1.0.4",
@@ -970,21 +839,10 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/fs.realpath": {
+		"node_modules/fs-constants": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -1009,25 +867,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/gauge": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.2",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.1",
-				"object-assign": "^4.1.1",
-				"signal-exit": "^3.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/get-intrinsic": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -1047,24 +886,10 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
 		},
 		"node_modules/glob-parent": {
 			"version": "5.1.2",
@@ -1089,12 +914,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"optional": true
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -1140,11 +959,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
-		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1156,12 +970,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/http-cache-semantics": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-			"optional": true
 		},
 		"node_modules/http-errors": {
 			"version": "2.0.0",
@@ -1178,85 +986,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/http-proxy-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-			"optional": true,
-			"dependencies": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/http-proxy-agent/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"optional": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/http-proxy-agent/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"optional": true
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/https-proxy-agent/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/https-proxy-agent/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"node_modules/humanize-ms": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"optional": true,
-			"dependencies": {
-				"ms": "^2.0.0"
-			}
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1269,63 +998,40 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/ignore-by-default": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
 			"integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
 			"dev": true
 		},
-		"node_modules/imurmurhash": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"optional": true,
-			"engines": {
-				"node": ">=0.8.19"
-			}
-		},
-		"node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"optional": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/infer-owner": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-			"optional": true
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"node_modules/ip-address": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 12"
-			}
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
@@ -1356,14 +1062,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1376,12 +1074,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-lambda": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-			"optional": true
-		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1391,12 +1083,6 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
-		},
-		"node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"optional": true
 		},
 		"node_modules/jake": {
 			"version": "10.8.7",
@@ -1415,13 +1101,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1433,59 +1112,10 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/make-dir/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-		},
-		"node_modules/make-fetch-happen": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-			"integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-			"optional": true,
-			"dependencies": {
-				"agentkeepalive": "^4.1.3",
-				"cacache": "^15.2.0",
-				"http-cache-semantics": "^4.1.0",
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"is-lambda": "^1.0.1",
-				"lru-cache": "^6.0.0",
-				"minipass": "^3.1.3",
-				"minipass-collect": "^1.0.2",
-				"minipass-fetch": "^1.3.2",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.2",
-				"promise-retry": "^2.0.1",
-				"socks-proxy-agent": "^6.0.0",
-				"ssri": "^8.0.0"
-			},
-			"engines": {
-				"node": ">= 10"
-			}
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
@@ -1539,6 +1169,17 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1550,104 +1191,18 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minipass-collect": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-			"optional": true,
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minipass-fetch": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-			"integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-			"optional": true,
-			"dependencies": {
-				"minipass": "^3.1.0",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.12"
-			}
-		},
-		"node_modules/minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-			"optional": true,
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minipass-pipeline": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-			"optional": true,
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-sized": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-			"optional": true,
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
 		"node_modules/morgan": {
 			"version": "1.10.0",
@@ -1680,6 +1235,11 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
+		"node_modules/napi-build-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1688,114 +1248,15 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/node-addon-api": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
-		},
-		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+		"node_modules/node-abi": {
+			"version": "3.67.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
+			"integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
 			"dependencies": {
-				"whatwg-url": "^5.0.0"
+				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/node-gyp": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-			"integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-			"optional": true,
-			"dependencies": {
-				"env-paths": "^2.2.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^9.1.0",
-				"nopt": "^5.0.0",
-				"npmlog": "^6.0.0",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"tar": "^6.1.2",
-				"which": "^2.0.2"
-			},
-			"bin": {
-				"node-gyp": "bin/node-gyp.js"
-			},
-			"engines": {
-				"node": ">= 10.12.0"
-			}
-		},
-		"node_modules/node-gyp/node_modules/are-we-there-yet": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-			"optional": true,
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/node-gyp/node_modules/gauge": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-			"optional": true,
-			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.3",
-				"console-control-strings": "^1.1.0",
-				"has-unicode": "^2.0.1",
-				"signal-exit": "^3.0.7",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.5"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/node-gyp/node_modules/nopt": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-			"optional": true,
-			"dependencies": {
-				"abbrev": "1"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/node-gyp/node_modules/npmlog": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-			"optional": true,
-			"dependencies": {
-				"are-we-there-yet": "^3.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^4.0.3",
-				"set-blocking": "^2.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/nodemon": {
@@ -1894,17 +1355,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/npmlog": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-			"dependencies": {
-				"are-we-there-yet": "^2.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^3.0.0",
-				"set-blocking": "^2.0.0"
-			}
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1952,35 +1402,12 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-			"optional": true,
-			"dependencies": {
-				"aggregate-error": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-to-regexp": {
@@ -2000,20 +1427,26 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/promise-inflight": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-			"optional": true
-		},
-		"node_modules/promise-retry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-			"optional": true,
+		"node_modules/prebuild-install": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+			"integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
 			"dependencies": {
-				"err-code": "^2.0.2",
-				"retry": "^0.12.0"
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -2036,6 +1469,15 @@
 			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
 			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
 			"dev": true
+		},
+		"node_modules/pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"node_modules/qs": {
 			"version": "6.11.0",
@@ -2075,6 +1517,20 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2098,29 +1554,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"optional": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -2203,11 +1636,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -2248,10 +1676,48 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
 		},
 		"node_modules/simple-update-notifier": {
 			"version": "2.0.0",
@@ -2263,109 +1729,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"optional": true,
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"ip-address": "^9.0.5",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks-proxy-agent": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-			"integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-			"optional": true,
-			"dependencies": {
-				"agent-base": "^6.0.2",
-				"debug": "^4.3.3",
-				"socks": "^2.6.2"
-			},
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/socks-proxy-agent/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"optional": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/socks-proxy-agent/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"optional": true
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"license": "BSD-3-Clause",
-			"optional": true
-		},
-		"node_modules/sqlite3": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.6.tgz",
-			"integrity": "sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"@mapbox/node-pre-gyp": "^1.0.0",
-				"node-addon-api": "^4.2.0",
-				"tar": "^6.1.11"
-			},
-			"optionalDependencies": {
-				"node-gyp": "8.x"
-			},
-			"peerDependencies": {
-				"node-gyp": "8.x"
-			},
-			"peerDependenciesMeta": {
-				"node-gyp": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/ssri": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-			"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-			"optional": true,
-			"dependencies": {
-				"minipass": "^3.1.1"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/statuses": {
@@ -2384,28 +1747,12 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
-		"node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
+		"node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/supports-color": {
@@ -2419,29 +1766,30 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"license": "ISC",
+		"node_modules/tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
 			}
 		},
-		"node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=6"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -2476,11 +1824,6 @@
 			"bin": {
 				"nodetouch": "bin/nodetouch.js"
 			}
-		},
-		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"node_modules/ts-node": {
 			"version": "10.9.2",
@@ -2524,6 +1867,17 @@
 				}
 			}
 		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -2560,24 +1914,6 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
-		"node_modules/unique-filename": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-			"optional": true,
-			"dependencies": {
-				"unique-slug": "^2.0.0"
-			}
-		},
-		"node_modules/unique-slug": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-			"optional": true,
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			}
-		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2610,43 +1946,6 @@
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-		},
-		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
-		},
-		"node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"optional": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"dependencies": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
 		"node_modules/wrappy": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,14 +11,15 @@
 	"author": "Ander \"Laquin\" Aginaga San Sebastián",
 	"license": "SEE LICENSE IN LICENSE",
 	"dependencies": {
+		"@types/better-sqlite3": "^7.6.11",
 		"@types/cors": "^2.8.17",
 		"@types/express": "^4.17.21",
 		"@types/morgan": "^1.9.9",
+		"better-sqlite3": "^11.2.1",
 		"cors": "^2.8.5",
 		"ejs": "^3.1.9",
 		"express": "^4.18.2",
 		"morgan": "^1.10.0",
-		"sqlite3": "^5.1.6",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.3.3"
 	},

--- a/server/src/controllers/languages-controller.ts
+++ b/server/src/controllers/languages-controller.ts
@@ -14,7 +14,11 @@ class LanguagesController
 	{
 		databaseManager.runQuery(
 			queries.addLanguage,
-			[name, dictionaryUrl, shouldShowSpaces]
+			{
+				name,
+				dictionaryUrl,
+				shouldShowSpaces,
+			}
 		);
 	}
 
@@ -22,7 +26,9 @@ class LanguagesController
 	{
 		databaseManager.runQuery(
 			queries.deleteLanguage,
-			[languageId]
+			{
+				languageId,
+			}
 		);
 	}
 
@@ -33,28 +39,28 @@ class LanguagesController
 		shouldShowSpaces: boolean
 	): void
 	{
-		const queryParams: any[] = [];
+		const queryParams: { [key: string]: any } = {};
 		const updates: string[] = [];
 	
 		if (name !== undefined)
 		{
-			updates.push('name = ?');
-			queryParams.push(name);
+			updates.push('name = :name');
+			queryParams.name = name;
 		}
 		if (dictionaryUrl !== undefined)
 		{
-			updates.push('dictionary_url = ?');
-			queryParams.push(dictionaryUrl);
+			updates.push('dictionary_url = :dictionaryUrl');
+			queryParams.dictionaryUrl = dictionaryUrl;
 		}
 		if (shouldShowSpaces !== undefined)
 		{
-			updates.push('should_show_spaces = ?');
-			queryParams.push(shouldShowSpaces);
+			updates.push('should_show_spaces = :shouldShowSpaces');
+			queryParams.shouldShowSpaces = shouldShowSpaces;
 		}
 
 		if (updates.length > 0)
 		{
-			queryParams.push(languageId);
+			queryParams.languageId = languageId;
 
 			const dynamicQuery: string = queries.editLanguage.replace(
 				/\%DYNAMIC\%/,
@@ -78,7 +84,9 @@ class LanguagesController
 	{
 		const language: Language = databaseManager.getFirstRow(
 			queries.getLanguage,
-			[languageId]
+			{
+				languageId,
+			}
 		);
 		
 		return language;

--- a/server/src/controllers/languages-controller.ts
+++ b/server/src/controllers/languages-controller.ts
@@ -12,7 +12,7 @@ class LanguagesController
 {
 	async addLanguage(name: string, dictionaryUrl: string, shouldShowSpaces: boolean): Promise<void>
 	{
-		await databaseManager.executeQuery(
+		await databaseManager.runQuery(
 			queries.addLanguage,
 			[name, dictionaryUrl, shouldShowSpaces]
 		);
@@ -20,7 +20,7 @@ class LanguagesController
 
 	async deleteLanguage(languageId: number): Promise<void>
 	{
-		await databaseManager.executeQuery(
+		await databaseManager.runQuery(
 			queries.deleteLanguage,
 			[languageId]
 		);
@@ -63,13 +63,13 @@ class LanguagesController
 				}
 			);
 
-			await databaseManager.executeQuery(dynamicQuery, queryParams);
+			await databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
 	async getAllLanguages(): Promise<Language[]>
 	{
-		const languages: Language[] = await databaseManager.executeQuery(queries.getAllLanguages);
+		const languages: Language[] = await databaseManager.getAllRows(queries.getAllLanguages);
 		
 		return languages;
 	}

--- a/server/src/controllers/languages-controller.ts
+++ b/server/src/controllers/languages-controller.ts
@@ -39,7 +39,7 @@ class LanguagesController
 		shouldShowSpaces: boolean
 	): void
 	{
-		const queryParams: { [key: string]: any } = {};
+		const queryParams: Record<string, any> = {};
 		const updates: string[] = [];
 	
 		if (name !== undefined)

--- a/server/src/controllers/languages-controller.ts
+++ b/server/src/controllers/languages-controller.ts
@@ -10,28 +10,28 @@ import { queries } from '../database/queries';
 
 class LanguagesController
 {
-	async addLanguage(name: string, dictionaryUrl: string, shouldShowSpaces: boolean): Promise<void>
+	addLanguage(name: string, dictionaryUrl: string, shouldShowSpaces: boolean): void
 	{
-		await databaseManager.runQuery(
+		databaseManager.runQuery(
 			queries.addLanguage,
 			[name, dictionaryUrl, shouldShowSpaces]
 		);
 	}
 
-	async deleteLanguage(languageId: number): Promise<void>
+	deleteLanguage(languageId: number): void
 	{
-		await databaseManager.runQuery(
+		databaseManager.runQuery(
 			queries.deleteLanguage,
 			[languageId]
 		);
 	}
 
-	async editLanguage(
+	editLanguage(
 		languageId: number,
 		name: string,
 		dictionaryUrl: string,
 		shouldShowSpaces: boolean
-	): Promise<void>
+	): void
 	{
 		const queryParams: any[] = [];
 		const updates: string[] = [];
@@ -63,20 +63,20 @@ class LanguagesController
 				}
 			);
 
-			await databaseManager.runQuery(dynamicQuery, queryParams);
+			databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
-	async getAllLanguages(): Promise<Language[]>
+	getAllLanguages(): Language[]
 	{
-		const languages: Language[] = await databaseManager.getAllRows(queries.getAllLanguages);
+		const languages: Language[] = databaseManager.getAllRows(queries.getAllLanguages);
 		
 		return languages;
 	}
 
-	async getLanguage(languageId: number): Promise<Language>
+	getLanguage(languageId: number): Language
 	{
-		const language: Language = await databaseManager.getFirstRow(
+		const language: Language = databaseManager.getFirstRow(
 			queries.getLanguage,
 			[languageId]
 		);

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -13,7 +13,7 @@ class PagesController
 {
 	async getPagesByText(textId: number): Promise<Page[]>
 	{
-		const pages: Page[] = await databaseManager.executeQuery(
+		const pages: Page[] = await databaseManager.getAllRows(
 			queries.getPagesByText,
 			[textId]
 		);
@@ -54,7 +54,7 @@ class PagesController
 				}
 			);
 
-			await databaseManager.executeQuery(dynamicQuery, queryParams);
+			await databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
@@ -83,7 +83,7 @@ class PagesController
 			}
 		);
 		
-		const wordData: ReducedWordData[] = await databaseManager.executeQuery(
+		const wordData: ReducedWordData[] = await databaseManager.getAllRows(
 			dynamicQuery,
 			[languageId, languageId]
 		);
@@ -92,7 +92,7 @@ class PagesController
 		{
 			if (wordData[i].potentialMultiword)
 			{
-				const potentialMultiwords: Word[] = await databaseManager.executeQuery(
+				const potentialMultiwords: Word[] = await databaseManager.getAllRows(
 					queries.getPotentialMultiwords,
 					[wordData[i].content, languageId]
 				);

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -15,7 +15,9 @@ class PagesController
 	{
 		const pages: Page[] = databaseManager.getAllRows(
 			queries.getPagesByText,
-			[textId]
+			{
+				textId,
+			}
 		);
 
 		return pages;
@@ -25,22 +27,30 @@ class PagesController
 	{
 		const page: Page = databaseManager.getFirstRow(
 			queries.getPage,
-			[textId, pagePosition]
+			{
+				textId,
+				pagePosition,
+			}
 		);
 
 		return page;
 	}
-	
+
 	getWords(textId: number, pagePosition: number): ReducedWordData[]
 	{
 		const page: Page = databaseManager.getFirstRow(
 			queries.getPage,
-			[textId, pagePosition]
+			{
+				textId,
+				pagePosition,
+			}
 		);
 
 		const languageId: number = databaseManager.getFirstRow(
 			queries.getText,
-			[page.textId]
+			{
+				textId,
+			}
 		).languageId;
 
 		const tokens: string[] = tokenizeString(page.content);
@@ -58,7 +68,9 @@ class PagesController
 		
 		const wordData: ReducedWordData[] = databaseManager.getAllRows(
 			dynamicQuery,
-			[languageId, languageId]
+			{
+				languageId,
+			}
 		);
 
 		for (let i = 0; i < wordData.length; i++)
@@ -67,7 +79,10 @@ class PagesController
 			{
 				const potentialMultiwords: Word[] = databaseManager.getAllRows(
 					queries.getPotentialMultiwords,
-					[wordData[i].content, languageId]
+					{
+						content: wordData[i].content,
+						languageId,
+					}
 				);
 
 				let multiword: Word | null = null;

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -11,9 +11,9 @@ import { queries } from "../database/queries";
 
 class PagesController
 {
-	async getPagesByText(textId: number): Promise<Page[]>
+	getPagesByText(textId: number): Page[]
 	{
-		const pages: Page[] = await databaseManager.getAllRows(
+		const pages: Page[] = databaseManager.getAllRows(
 			queries.getPagesByText,
 			[textId]
 		);
@@ -21,9 +21,9 @@ class PagesController
 		return pages;
 	}
 
-	async getPage(textId: number, pagePosition: number): Promise<Page>
+	getPage(textId: number, pagePosition: number): Page
 	{
-		const page: Page = await databaseManager.getFirstRow(
+		const page: Page = databaseManager.getFirstRow(
 			queries.getPage,
 			[textId, pagePosition]
 		);
@@ -31,7 +31,7 @@ class PagesController
 		return page;
 	}
 
-	async editPage(textId: number, index: number, content: string, pagePosition: number): Promise<void>
+	editPage(textId: number, index: number, content: string, pagePosition: number): void
 	{
 		const queryParams: any[] = [];
 		const updates: string[] = [];
@@ -54,21 +54,21 @@ class PagesController
 				}
 			);
 
-			await databaseManager.runQuery(dynamicQuery, queryParams);
+			databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
-	async getWords(textId: number, pagePosition: number): Promise<ReducedWordData[]>
+	getWords(textId: number, pagePosition: number): ReducedWordData[]
 	{
-		const page: Page = await databaseManager.getFirstRow(
+		const page: Page = databaseManager.getFirstRow(
 			queries.getPage,
 			[textId, pagePosition]
 		);
 
-		const languageId: number = (await databaseManager.getFirstRow(
+		const languageId: number = databaseManager.getFirstRow(
 			queries.getText,
 			[page.textId]
-		)).languageId;
+		).languageId;
 
 		const tokens: string[] = tokenizeString(page.content);
 		
@@ -83,7 +83,7 @@ class PagesController
 			}
 		);
 		
-		const wordData: ReducedWordData[] = await databaseManager.getAllRows(
+		const wordData: ReducedWordData[] = databaseManager.getAllRows(
 			dynamicQuery,
 			[languageId, languageId]
 		);
@@ -92,7 +92,7 @@ class PagesController
 		{
 			if (wordData[i].potentialMultiword)
 			{
-				const potentialMultiwords: Word[] = await databaseManager.getAllRows(
+				const potentialMultiwords: Word[] = databaseManager.getAllRows(
 					queries.getPotentialMultiwords,
 					[wordData[i].content, languageId]
 				);

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -30,34 +30,7 @@ class PagesController
 
 		return page;
 	}
-
-	editPage(textId: number, index: number, content: string, pagePosition: number): void
-	{
-		const queryParams: any[] = [];
-		const updates: string[] = [];
-
-		if (content !== undefined)
-		{
-			updates.push('content = ?');
-			queryParams.push(content);
-		}
-		
-		if (updates.length > 0)
-		{
-			queryParams.push(textId);
-			queryParams.push(pagePosition);
-
-			const dynamicQuery: string = queries.editPage.replace(
-				/\%DYNAMIC\%/,
-				(): string => {
-					return updates.join(', ');
-				}
-			);
-
-			databaseManager.runQuery(dynamicQuery, queryParams);
-		}
-	}
-
+	
 	getWords(textId: number, pagePosition: number): ReducedWordData[]
 	{
 		const page: Page = databaseManager.getFirstRow(

--- a/server/src/controllers/statistics-controller.ts
+++ b/server/src/controllers/statistics-controller.ts
@@ -9,12 +9,12 @@ import { queries } from "../database/queries";
 
 class StatisticsController
 {
-	async getWordsImprovedCount(languageId: number): Promise<{wordsImprovedCount: number}>
+	getWordsImprovedCount(languageId: number): {wordsImprovedCount: number}
 	{
 		return {
-			wordsImprovedCount: (await databaseManager.getFirstRow(
+			wordsImprovedCount: databaseManager.getFirstRow(
 				queries.getWordsImprovedCount, [languageId]
-			)).wordsImprovedCount
+			).wordsImprovedCount
 		};
 	}
 }

--- a/server/src/controllers/statistics-controller.ts
+++ b/server/src/controllers/statistics-controller.ts
@@ -13,7 +13,7 @@ class StatisticsController
 	{
 		return {
 			wordsImprovedCount: databaseManager.getFirstRow(
-				queries.getWordsImprovedCount, [languageId]
+				queries.getWordsImprovedCount, { languageId }
 			).wordsImprovedCount
 		};
 	}

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -10,34 +10,34 @@ import { queries } from "../database/queries";
 
 class TextsController
 {
-	async addText(
+	addText(
 		languageId: number,
 		title: string,
 		content: string,
 		sourceUrl: string,
 		numberOfPages: number
-	): Promise<void>
+	): void
 	{
-		await databaseManager.runQuery(
+		databaseManager.runQuery(
 			queries.addText,
 			[languageId, title, sourceUrl]
 		);
 
-		const textId: number = (await databaseManager.getLastInsertId()).id;
+		const textId: number = databaseManager.getLastInsertId().id;
 
-		await this.updatePage(textId, numberOfPages, content);
+		this.updatePage(textId, numberOfPages, content);
 	}
 
-	async getAllTexts(): Promise<Text[]>
+	getAllTexts(): Text[]
 	{
-		const texts: Text[] = await databaseManager.getAllRows(queries.getAllTexts);
+		const texts: Text[] = databaseManager.getAllRows(queries.getAllTexts);
 
 		return texts;
 	}
 
-	async getTextsByLanguage(languageId: number): Promise<Text[]>
+	getTextsByLanguage(languageId: number): Text[]
 	{
-		const texts: Text[] = await databaseManager.getAllRows(
+		const texts: Text[] = databaseManager.getAllRows(
 			queries.getTextsByLanguage,
 			[languageId]
 		);
@@ -45,9 +45,9 @@ class TextsController
 		return texts;
 	}
 
-	async getText(textId: number): Promise<Text>
+	getText(textId: number): Text
 	{
-		const text: Text = await databaseManager.getFirstRow(
+		const text: Text = databaseManager.getFirstRow(
 			queries.getText,
 			[textId]
 		);
@@ -55,30 +55,30 @@ class TextsController
 		return text;
 	}
 
-	async getNumberOfPages(textId: number): Promise<number>
+	getNumberOfPages(textId: number): number
 	{
-		const numberOfPages: number = (await databaseManager.getAllRows(
+		const numberOfPages: number = databaseManager.getAllRows(
 			queries.getPagesByText,
 			[textId]
-		)).length;
+		).length;
 
 		return numberOfPages;
 	}
 
-	async deleteText(textId: number): Promise<void>
+	deleteText(textId: number): void
 	{
-		await databaseManager.runQuery(
+		databaseManager.runQuery(
 			queries.deletePagesByText,
 			[textId]
 		);
 
-		await databaseManager.runQuery(
+		databaseManager.runQuery(
 			queries.deleteText,
 			[textId]
 		);
 	}
 
-	async editText(
+	editText(
 		languageId: number,
 		title: string,
 		sourceUrl: string,
@@ -88,14 +88,14 @@ class TextsController
 		timeOpened: number,
 		timeFinished: number,
 		progress: number
-	): Promise<void>
+	): void
 	{
 		const queryParams: any[] = [];
 		const updates: string[] = [];
 	
 		if (languageId !== undefined)
 		{
-			const language = await databaseManager.getFirstRow(
+			const language = databaseManager.getFirstRow(
 				queries.getLanguage,
 				[languageId]
 			);
@@ -134,7 +134,7 @@ class TextsController
 		}
 		if (numberOfPages !== undefined || content !== undefined)
 		{
-			await this.updatePage(textId, numberOfPages, content);
+			this.updatePage(textId, numberOfPages, content);
 		}
 
 		if (updates.length > 0)
@@ -148,13 +148,13 @@ class TextsController
 				}
 			);
 
-			await databaseManager.runQuery(dynamicQuery, queryParams);
+			databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
-	private async updatePage(textId: number, numberOfPages: number, content: string)
+	private updatePage(textId: number, numberOfPages: number, content: string)
 	{
-		const pages: Page[] = await databaseManager.getAllRows(
+		const pages: Page[] = databaseManager.getAllRows(
 			queries.getPagesByText,
 			[textId]
 		);
@@ -185,7 +185,7 @@ class TextsController
 			newPageContents[i] = sentences.slice(firstPageIndex, lastPageIndex+1).join('');
 			if (i < pages.length)
 			{
-				await databaseManager.runQuery(
+				databaseManager.runQuery(
 					queries.editPage,
 					[newPageContents[i], textId, i + 1]
 				);
@@ -209,11 +209,11 @@ class TextsController
 				}
 			);
 
-			await databaseManager.runQuery(dynamicQuery);
+			databaseManager.runQuery(dynamicQuery);
 		}
 		if (newNumberOfPages < pages.length)
 		{
-			await databaseManager.runQuery(
+			databaseManager.runQuery(
 				queries.deletePagesInBatch,
 				[textId, newNumberOfPages + 1]
 			);

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -104,7 +104,7 @@ class TextsController
 		progress: number
 	): void
 	{
-		const queryParams: { [key: string]: any } = {};
+		const queryParams: Record<string, any> = {};
 		const updates: string[] = [];
 	
 		if (languageId !== undefined)

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -20,7 +20,11 @@ class TextsController
 	{
 		databaseManager.runQuery(
 			queries.addText,
-			[languageId, title, sourceUrl]
+			{
+				languageId,
+				title,
+				sourceUrl,
+			}
 		);
 
 		const textId: number = databaseManager.getLastInsertId().id;
@@ -39,7 +43,9 @@ class TextsController
 	{
 		const texts: Text[] = databaseManager.getAllRows(
 			queries.getTextsByLanguage,
-			[languageId]
+			{
+				languageId,
+			}
 		);
 
 		return texts;
@@ -49,7 +55,9 @@ class TextsController
 	{
 		const text: Text = databaseManager.getFirstRow(
 			queries.getText,
-			[textId]
+			{
+				textId,
+			}
 		);
 
 		return text;
@@ -59,7 +67,9 @@ class TextsController
 	{
 		const numberOfPages: number = databaseManager.getAllRows(
 			queries.getPagesByText,
-			[textId]
+			{
+				textId,
+			}
 		).length;
 
 		return numberOfPages;
@@ -69,12 +79,16 @@ class TextsController
 	{
 		databaseManager.runQuery(
 			queries.deletePagesByText,
-			[textId]
+			{
+				textId,
+			}
 		);
 
 		databaseManager.runQuery(
 			queries.deleteText,
-			[textId]
+			{
+				textId,
+			}
 		);
 	}
 
@@ -90,47 +104,49 @@ class TextsController
 		progress: number
 	): void
 	{
-		const queryParams: any[] = [];
+		const queryParams: { [key: string]: any } = {};
 		const updates: string[] = [];
 	
 		if (languageId !== undefined)
 		{
 			const language = databaseManager.getFirstRow(
 				queries.getLanguage,
-				[languageId]
+				{
+					languageId,
+				}
 			);
 			if (!language)
 			{
 				console.error('Language does not exist.');
 				return;
 			}
-			updates.push('language_id = ?');
-			queryParams.push(languageId);
+			updates.push('language_id = :languageId');
+			queryParams.languageId = languageId;
 		}
 		if (title !== undefined)
 		{
-			updates.push('title = ?');
-			queryParams.push(title);
+			updates.push('title = :title');
+			queryParams.title = title;
 		}
 		if (sourceUrl !== undefined)
 		{
-			updates.push('source_url = ?');
-			queryParams.push(sourceUrl);
+			updates.push('source_url = :sourceUrl');
+			queryParams.sourceUrl = sourceUrl;
 		}
 		if (timeOpened !== undefined)
 		{
-			updates.push('time_opened = ?');
-			queryParams.push(timeOpened);
+			updates.push('time_opened = :timeOpened');
+			queryParams.timeOpened = timeOpened;
 		}
 		if (timeFinished !== undefined)
 		{
-			updates.push('time_finished = ?');
-			queryParams.push(timeFinished);
+			updates.push('time_finished = :timeFinished');
+			queryParams.timeFinished = timeFinished;
 		}
 		if (progress !== undefined)
 		{
-			updates.push('progress = ?');
-			queryParams.push(progress);
+			updates.push('progress = :progress');
+			queryParams.progress = progress;
 		}
 		if (numberOfPages !== undefined || content !== undefined)
 		{
@@ -139,7 +155,7 @@ class TextsController
 
 		if (updates.length > 0)
 		{
-			queryParams.push(textId);
+			queryParams.textId = textId;
 
 			const dynamicQuery: string = queries.editText.replace(
 				/\%DYNAMIC\%/,
@@ -156,7 +172,9 @@ class TextsController
 	{
 		const pages: Page[] = databaseManager.getAllRows(
 			queries.getPagesByText,
-			[textId]
+			{
+				textId,
+			}
 		);
 
 		const newNumberOfPages: number = (numberOfPages !== undefined) ? numberOfPages : pages.length;
@@ -187,7 +205,11 @@ class TextsController
 			{
 				databaseManager.runQuery(
 					queries.editPage,
-					[newPageContents[i], textId, i + 1]
+					{
+						content: newPageContents[i],
+						textId,
+						pagePosition: i + 1,
+					}
 				);
 			}
 
@@ -215,7 +237,10 @@ class TextsController
 		{
 			databaseManager.runQuery(
 				queries.deletePagesInBatch,
-				[textId, newNumberOfPages + 1]
+				{
+					textId,
+					pagePosition: newNumberOfPages + 1,
+				}
 			);
 		}
 	}

--- a/server/src/controllers/texts-controller.ts
+++ b/server/src/controllers/texts-controller.ts
@@ -18,7 +18,7 @@ class TextsController
 		numberOfPages: number
 	): Promise<void>
 	{
-		await databaseManager.executeQuery(
+		await databaseManager.runQuery(
 			queries.addText,
 			[languageId, title, sourceUrl]
 		);
@@ -30,14 +30,14 @@ class TextsController
 
 	async getAllTexts(): Promise<Text[]>
 	{
-		const texts: Text[] = await databaseManager.executeQuery(queries.getAllTexts);
+		const texts: Text[] = await databaseManager.getAllRows(queries.getAllTexts);
 
 		return texts;
 	}
 
 	async getTextsByLanguage(languageId: number): Promise<Text[]>
 	{
-		const texts: Text[] = await databaseManager.executeQuery(
+		const texts: Text[] = await databaseManager.getAllRows(
 			queries.getTextsByLanguage,
 			[languageId]
 		);
@@ -57,7 +57,7 @@ class TextsController
 
 	async getNumberOfPages(textId: number): Promise<number>
 	{
-		const numberOfPages: number = (await databaseManager.executeQuery(
+		const numberOfPages: number = (await databaseManager.getAllRows(
 			queries.getPagesByText,
 			[textId]
 		)).length;
@@ -67,12 +67,12 @@ class TextsController
 
 	async deleteText(textId: number): Promise<void>
 	{
-		await databaseManager.executeQuery(
+		await databaseManager.runQuery(
 			queries.deletePagesByText,
 			[textId]
 		);
 
-		await databaseManager.executeQuery(
+		await databaseManager.runQuery(
 			queries.deleteText,
 			[textId]
 		);
@@ -148,13 +148,13 @@ class TextsController
 				}
 			);
 
-			await databaseManager.executeQuery(dynamicQuery, queryParams);
+			await databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
 	private async updatePage(textId: number, numberOfPages: number, content: string)
 	{
-		const pages: Page[] = await databaseManager.executeQuery(
+		const pages: Page[] = await databaseManager.getAllRows(
 			queries.getPagesByText,
 			[textId]
 		);
@@ -185,7 +185,7 @@ class TextsController
 			newPageContents[i] = sentences.slice(firstPageIndex, lastPageIndex+1).join('');
 			if (i < pages.length)
 			{
-				await databaseManager.executeQuery(
+				await databaseManager.runQuery(
 					queries.editPage,
 					[newPageContents[i], textId, i + 1]
 				);
@@ -209,11 +209,11 @@ class TextsController
 				}
 			);
 
-			await databaseManager.executeQuery(dynamicQuery);
+			await databaseManager.runQuery(dynamicQuery);
 		}
 		if (newNumberOfPages < pages.length)
 		{
-			await databaseManager.executeQuery(
+			await databaseManager.runQuery(
 				queries.deletePagesInBatch,
 				[textId, newNumberOfPages + 1]
 			);

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -23,7 +23,7 @@ class WordsController
 	{
 		const tokenizedContent: string[] = tokenizeString(content);
 
-		await databaseManager.executeQuery(
+		await databaseManager.runQuery(
 			queries.addWord,
 			[languageId, content, status, notes, timeAdded, timeUpdated, tokenizedContent.length]
 		);
@@ -32,7 +32,7 @@ class WordsController
 
 		for (let i = 0; i < entries.length; i++)
 		{
-			await databaseManager.executeQuery(
+			await databaseManager.runQuery(
 				queries.addEntry,
 				[wordId, i, entries[i].meaning, entries[i].reading]
 			);
@@ -63,7 +63,7 @@ class WordsController
 			}
 		);
 
-		await databaseManager.executeQuery(dynamicQuery);
+		await databaseManager.runQuery(dynamicQuery);
 	}
 
 	async getWord(wordId: number): Promise<Word>
@@ -73,7 +73,7 @@ class WordsController
 			[wordId]
 		);
 
-		const entries: Entry[] = await databaseManager.executeQuery(
+		const entries: Entry[] = await databaseManager.getAllRows(
 			queries.getEntriesByWord,
 			[wordId]
 		);
@@ -98,7 +98,7 @@ class WordsController
 			return null;
 		}
 
-		const entries: Entry[] = await databaseManager.executeQuery(
+		const entries: Entry[] = await databaseManager.getAllRows(
 			queries.getEntriesByWord,
 			[rawWord.id]
 		);
@@ -113,7 +113,7 @@ class WordsController
 
 	async deleteWord(wordId: number): Promise<void>
 	{
-		await databaseManager.executeQuery(
+		await databaseManager.getAllRows(
 			queries.deleteWord,
 			[wordId]
 		);
@@ -193,13 +193,13 @@ class WordsController
 				}
 			);
 
-			await databaseManager.executeQuery(dynamicQuery, queryParams);
+			await databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
 	async updateEntries(wordId: number, entries: Entry[]): Promise<void>
 	{
-		await databaseManager.executeQuery(
+		await databaseManager.runQuery(
 			queries.deleteEntriesByWord,
 			[wordId]
 		);
@@ -224,7 +224,7 @@ class WordsController
 			}
 		);
 
-		await databaseManager.executeQuery(dynamicQuery);
+		await databaseManager.runQuery(dynamicQuery);
 	}
 }
 

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -11,7 +11,7 @@ import { queries } from "../database/queries";
 
 class WordsController
 {
-	async addWord(
+	addWord(
 		languageId: number,
 		content: string,
 		status: number,
@@ -19,32 +19,32 @@ class WordsController
 		notes: string,
 		timeAdded: number,
 		timeUpdated: number
-	): Promise<void>
+	): void
 	{
 		const tokenizedContent: string[] = tokenizeString(content);
 
-		await databaseManager.runQuery(
+		databaseManager.runQuery(
 			queries.addWord,
 			[languageId, content, status, notes, timeAdded, timeUpdated, tokenizedContent.length]
 		);
 
-		const wordId: number = (await databaseManager.getLastInsertId()).id;
+		const wordId: number = databaseManager.getLastInsertId().id;
 
 		for (let i = 0; i < entries.length; i++)
 		{
-			await databaseManager.runQuery(
+			databaseManager.runQuery(
 				queries.addEntry,
 				[wordId, i, entries[i].meaning, entries[i].reading]
 			);
 		}
 	}
 
-	async addWordsInBatch(
+	addWordsInBatch(
 		languageId: number,
 		contents: string[],
 		status: number,
 		timeAdded: number
-	): Promise<void>
+	): void
 	{
 		const valueList: string[] = [];
 		for (const content of contents)
@@ -63,17 +63,17 @@ class WordsController
 			}
 		);
 
-		await databaseManager.runQuery(dynamicQuery);
+		databaseManager.runQuery(dynamicQuery);
 	}
 
-	async getWord(wordId: number): Promise<Word>
+	getWord(wordId: number): Word
 	{
-		const rawWord: RawWord = await databaseManager.getFirstRow(
+		const rawWord: RawWord = databaseManager.getFirstRow(
 			queries.getWord,
 			[wordId]
 		);
 
-		const entries: Entry[] = await databaseManager.getAllRows(
+		const entries: Entry[] = databaseManager.getAllRows(
 			queries.getEntriesByWord,
 			[wordId]
 		);
@@ -86,9 +86,9 @@ class WordsController
 		return word;
 	}
 
-	async findWord(content: string, languageId: number): Promise<Word | null>
+	findWord(content: string, languageId: number): Word | null
 	{
-		const rawWord: RawWord | null = await databaseManager.getFirstRow(
+		const rawWord: RawWord | null = databaseManager.getFirstRow(
 			queries.findWord,
 			[content, languageId]
 		);
@@ -98,7 +98,7 @@ class WordsController
 			return null;
 		}
 
-		const entries: Entry[] = await databaseManager.getAllRows(
+		const entries: Entry[] = databaseManager.getAllRows(
 			queries.getEntriesByWord,
 			[rawWord.id]
 		);
@@ -111,15 +111,15 @@ class WordsController
 		return word;
 	}
 
-	async deleteWord(wordId: number): Promise<void>
+	deleteWord(wordId: number): void
 	{
-		await databaseManager.getAllRows(
+		databaseManager.getAllRows(
 			queries.deleteWord,
 			[wordId]
 		);
 	}
 
-	async editWord(
+	editWord(
 		languageId: number,
 		content: string,
 		status: number,
@@ -128,14 +128,14 @@ class WordsController
 		timeAdded: number,
 		timeUpdated: number,
 		wordId: number
-	): Promise<void>
+	): void
 	{
 		const queryParams: any[] = [];
 		const updates: string[] = [];
 	
 		if (languageId !== undefined)
 		{
-			const language = await databaseManager.getFirstRow(
+			const language = databaseManager.getFirstRow(
 				queries.getLanguage,
 				[languageId]
 			);
@@ -164,7 +164,7 @@ class WordsController
 		}
 		if (entries !== undefined)
 		{
-			await this.updateEntries(wordId, entries);
+			this.updateEntries(wordId, entries);
 		}
 		if (notes !== undefined)
 		{
@@ -193,13 +193,13 @@ class WordsController
 				}
 			);
 
-			await databaseManager.runQuery(dynamicQuery, queryParams);
+			databaseManager.runQuery(dynamicQuery, queryParams);
 		}
 	}
 
-	async updateEntries(wordId: number, entries: Entry[]): Promise<void>
+	updateEntries(wordId: number, entries: Entry[]): void
 	{
-		await databaseManager.runQuery(
+		databaseManager.runQuery(
 			queries.deleteEntriesByWord,
 			[wordId]
 		);
@@ -224,7 +224,7 @@ class WordsController
 			}
 		);
 
-		await databaseManager.runQuery(dynamicQuery);
+		databaseManager.runQuery(dynamicQuery);
 	}
 }
 

--- a/server/src/controllers/words-controller.ts
+++ b/server/src/controllers/words-controller.ts
@@ -154,7 +154,7 @@ class WordsController
 		wordId: number
 	): void
 	{
-		const queryParams: { [key: string]: any } = {};
+		const queryParams: Record<string, any> = {};
 		const updates: string[] = [];
 	
 		if (languageId !== undefined)

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -5,10 +5,8 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 import Database from 'better-sqlite3';
 
-import { getEnvironmentVariable } from '../../../common/utils';
 import { queries } from './queries';
 
 class DatabaseManager
@@ -43,14 +41,7 @@ class DatabaseManager
 			}
 		}
 
-		const options: Database.Options = {
-			readonly: false,
-		};
-
-		this.database = new Database(
-			databaseFilePath,
-			options
-		);
+		this.database = new Database(databaseFilePath);
 
 		console.log('Connected to ' + databaseFilePath);
 
@@ -67,26 +58,26 @@ class DatabaseManager
 		this.database = null;
 	}
 
-	async initializeDatabase(): Promise<void>
+	initializeDatabase(): void
 	{
 		// Create tables
-		await this.runQuery(queries.createConfigurationTable);
-		await this.runQuery(queries.createLanguageTable);
-		await this.runQuery(queries.createTextTable);
-		await this.runQuery(queries.createPageTable);
-		await this.runQuery(queries.createWordTable);
-		await this.runQuery(queries.createEntryTable);
-		await this.runQuery(queries.createStatusLogTable);
+		this.runQuery(queries.createConfigurationTable);
+		this.runQuery(queries.createLanguageTable);
+		this.runQuery(queries.createTextTable);
+		this.runQuery(queries.createPageTable);
+		this.runQuery(queries.createWordTable);
+		this.runQuery(queries.createEntryTable);
+		this.runQuery(queries.createStatusLogTable);
 
 		// Create indexes
-		await this.runQuery(queries.createTextLanguageIdTitleIndex);
-		await this.runQuery(queries.createWordLowerContentLanguageIdIndex);
-		await this.runQuery(queries.createWordLanguageIdTokenCountContentIndex);
+		this.runQuery(queries.createTextLanguageIdTitleIndex);
+		this.runQuery(queries.createWordLowerContentLanguageIdIndex);
+		this.runQuery(queries.createWordLanguageIdTokenCountContentIndex);
 
 		// Create triggers
-		await this.runQuery(queries.createInsertStatusLogAfterInsertWordTrigger);
-		await this.runQuery(queries.createInsertStatusLogAfterUpdateWordTrigger);
-		await this.runQuery(queries.createDeleteStatusLogAfterDeleteWordTrigger);
+		this.runQuery(queries.createInsertStatusLogAfterInsertWordTrigger);
+		this.runQuery(queries.createInsertStatusLogAfterUpdateWordTrigger);
+		this.runQuery(queries.createDeleteStatusLogAfterDeleteWordTrigger);
 	}
 
 	runQuery(query: string, parameters: any[] = []): void
@@ -125,12 +116,12 @@ class DatabaseManager
 		return this.database.prepare(query).get(parameters);
 	}
 
-	getLastInsertId(): Promise<any>
+	getLastInsertId(): any
 	{
 		return this.getFirstRow(queries.getLastInsertId);
 	}
 
-	fixParameters(parameters: any[]): any[]
+	private fixParameters(parameters: any[]): any[]
 	{
 		return parameters.map(
 			parameter => {
@@ -143,8 +134,6 @@ class DatabaseManager
 		);
 	}
 }
-
-const databaseFileName: string = 'database.db';
 
 const databaseManager = new DatabaseManager();
 

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -80,7 +80,7 @@ class DatabaseManager
 		this.runQuery(queries.createDeleteStatusLogAfterDeleteWordTrigger);
 	}
 
-	runQuery(query: string, parameters: { [key: string]: any } = {}): void
+	runQuery(query: string, parameters: Record<string, any> = {}): void
 	{
 		if (this.database === null)
 		{
@@ -92,7 +92,7 @@ class DatabaseManager
 		this.database.prepare(query).run(parameters);
 	}
 
-	getAllRows(query: string, parameters: { [key: string]: any } = {}): any[]
+	getAllRows(query: string, parameters: Record<string, any> = {}): any[]
 	{
 		if (this.database === null)
 		{
@@ -104,7 +104,7 @@ class DatabaseManager
 		return this.database.prepare(query).all(parameters);
 	}
 
-	getFirstRow(query: string, parameters: { [key: string]: any } = {}): any
+	getFirstRow(query: string, parameters: Record<string, any> = {}): any
 	{
 		if (this.database === null)
 		{
@@ -121,10 +121,10 @@ class DatabaseManager
 		return this.getFirstRow(queries.getLastInsertId);
 	}
 
-	private fixParameters(parameters: { [key: string]: any }): Object
+	private fixParameters(parameters: Record<string, any>): Object
 	{
 		for (const key in parameters)
-			{
+		{
 			if (typeof parameters[key] === 'boolean')
 			{
 				parameters[key] = parameters[key] ? 1 : 0;

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -80,7 +80,7 @@ class DatabaseManager
 		this.runQuery(queries.createDeleteStatusLogAfterDeleteWordTrigger);
 	}
 
-	runQuery(query: string, parameters: any[] = []): void
+	runQuery(query: string, parameters: { [key: string]: any } = {}): void
 	{
 		if (this.database === null)
 		{
@@ -92,7 +92,7 @@ class DatabaseManager
 		this.database.prepare(query).run(parameters);
 	}
 
-	getAllRows(query: string, parameters: any[] = []): any[]
+	getAllRows(query: string, parameters: { [key: string]: any } = {}): any[]
 	{
 		if (this.database === null)
 		{
@@ -104,7 +104,7 @@ class DatabaseManager
 		return this.database.prepare(query).all(parameters);
 	}
 
-	getFirstRow(query: string, parameters: any[] = []): any
+	getFirstRow(query: string, parameters: { [key: string]: any } = {}): any
 	{
 		if (this.database === null)
 		{
@@ -121,17 +121,16 @@ class DatabaseManager
 		return this.getFirstRow(queries.getLastInsertId);
 	}
 
-	private fixParameters(parameters: any[]): any[]
+	private fixParameters(parameters: { [key: string]: any }): Object
 	{
-		return parameters.map(
-			parameter => {
-				if (typeof parameter === "boolean")
-				{
-					return parameter ? 1 : 0;
-				}
-				return parameter;
+		for (const key in parameters)
+			{
+			if (typeof parameters[key] === 'boolean')
+			{
+				parameters[key] = parameters[key] ? 1 : 0;
 			}
-		);
+		}
+		return parameters;
 	}
 }
 

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -4,7 +4,7 @@
  * Licensed under version 3 of the GNU Affero General Public License
  */
 
-const queries: { [key: string]: string } = {
+const queries: Record<string, string> = {
 	//#region Create tables
 	createConfigurationTable: `CREATE TABLE IF NOT EXISTS configuration (
 		key TEXT NOT NULL,

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -142,15 +142,15 @@ const queries: { [key: string]: string } = {
 			name,
 			dictionary_url AS dictionaryUrl,
 			should_show_spaces AS shouldShowSpaces
-		FROM language WHERE id = ?`,
+		FROM language WHERE id = :languageId`,
 	addLanguage: `INSERT INTO language (
 			name,
 			dictionary_url,
 			should_show_spaces
 		)
-		VALUES (?, ?, ?)`,
-	deleteLanguage: `DELETE FROM language WHERE id = ?`,
-	editLanguage: `UPDATE language SET %DYNAMIC% WHERE id = ?`,
+		VALUES (:name, :dictionaryUrl, :shouldShowSpaces)`,
+	deleteLanguage: `DELETE FROM language WHERE id = :languageId`,
+	editLanguage: `UPDATE language SET %DYNAMIC% WHERE id = :languageId`,
 	//#endregion
 
 	//#region Text
@@ -172,7 +172,7 @@ const queries: { [key: string]: string } = {
 			time_finished AS timeFinished,
 			progress
 		FROM text
-		WHERE language_id = ?`,
+		WHERE language_id = :languageId`,
 	getText: `SELECT
 			id,
 			language_id AS languageId,
@@ -182,15 +182,15 @@ const queries: { [key: string]: string } = {
 			time_finished AS timeFinished,
 			progress
 		FROM text
-		WHERE id = ?`,
+		WHERE id = :textId`,
 	addText: `INSERT INTO text (
 			language_id,
 			title,
 			source_url
 		)
-		VALUES (?, ?, ?)`,
-	deleteText: `DELETE FROM text WHERE id = ?`,
-	editText: `UPDATE text SET %DYNAMIC% WHERE id = ?`,
+		VALUES (:languageId, :title, :sourceUrl)`,
+	deleteText: `DELETE FROM text WHERE id = :textId`,
+	editText: `UPDATE text SET %DYNAMIC% WHERE id = :textId`,
 	//#endregion
 
 	//#region Page
@@ -199,29 +199,29 @@ const queries: { [key: string]: string } = {
 			position,
 			content
 		FROM page
-		WHERE text_id = ?`,
+		WHERE text_id = :textId`,
 	getPage: `SELECT
 			text_id AS textId,
 			position,
 			content
 		FROM page
-		WHERE text_id = ? AND position = ?`,
+		WHERE text_id = :textId AND position = :pagePosition`,
 	addPage: `INSERT INTO page (
 			text_id,
 			position,
 			content
 		)
-		VALUES (?, ?, ?)`,
+		VALUES (:textId, :position, :content)`,
 	addPagesInBatch: `INSERT INTO page (
 			text_id,
 			position,
 			content
 		)
 		VALUES %DYNAMIC%`,
-	deletePage: `DELETE FROM page WHERE text_id = ? AND position = ?`,
-	deletePagesInBatch: `DELETE FROM page WHERE text_id = ? AND position >= ?`,
-	deletePagesByText: `DELETE FROM page WHERE text_id = ?`,
-	editPage: `UPDATE page SET content = ? WHERE text_id = ? AND position = ?`,
+	deletePage: `DELETE FROM page WHERE text_id = :textId AND position = :pagePosition`,
+	deletePagesInBatch: `DELETE FROM page WHERE text_id = :textId AND position >= :pagePosition`,
+	deletePagesByText: `DELETE FROM page WHERE text_id = :textId`,
+	editPage: `UPDATE page SET content = :content WHERE text_id = :textId AND position = :pagePosition`,
 	//#endregion
 
 	//#region Word
@@ -235,7 +235,7 @@ const queries: { [key: string]: string } = {
 			time_updated AS timeUpdated,
 			token_count AS tokenCount
 		FROM word
-		WHERE id = ?`,
+		WHERE id = :wordId`,
 	findWord: `SELECT
 			id,
 			language_id AS languageId,
@@ -246,7 +246,7 @@ const queries: { [key: string]: string } = {
 			time_updated AS timeUpdated,
 			token_count AS tokenCount
 		FROM word
-		WHERE LOWER(content) = LOWER(?) AND language_id = ?`,
+		WHERE LOWER(content) = LOWER(:content) AND language_id = :languageId`,
 	findWordsInBatch: `WITH input_words(content) AS (VALUES %DYNAMIC%)
 		SELECT
 			input_words.content AS content,
@@ -262,10 +262,10 @@ const queries: { [key: string]: string } = {
 			EXISTS (
 				SELECT token_count
 				FROM word
-				WHERE word.content LIKE (input_words.content || '%') AND word.language_id = ? AND word.token_count > 1
+				WHERE word.content LIKE (input_words.content || '%') AND word.language_id = :languageId AND word.token_count > 1
 			) AS potentialMultiword
 		FROM input_words
-		LEFT JOIN word ON LOWER(input_words.content) = LOWER(word.content) AND word.language_id = ?`,
+		LEFT JOIN word ON LOWER(input_words.content) = LOWER(word.content) AND word.language_id = :languageId`,
 	addWord: `INSERT INTO word (
 			language_id,
 			content,
@@ -275,7 +275,7 @@ const queries: { [key: string]: string } = {
 			time_updated,
 			token_count
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (:languageId, :content, :status, :notes, :timeAdded, :timeUpdated, :tokenCount)`,
 	addWordsInBatch: `INSERT INTO word (
 			language_id,
 			content,
@@ -286,8 +286,8 @@ const queries: { [key: string]: string } = {
 			token_count
 		)
 		VALUES %DYNAMIC%`,
-	deleteWord: `DELETE FROM word WHERE id = ?`,
-	editWord: `UPDATE word SET %DYNAMIC% WHERE id = ?`,
+	deleteWord: `DELETE FROM word WHERE id = :wordId`,
+	editWord: `UPDATE word SET %DYNAMIC% WHERE id = :wordId`,
 	getPotentialMultiwords: `SELECT
 			id,
 			language_id AS languageId,
@@ -298,8 +298,8 @@ const queries: { [key: string]: string } = {
 			time_updated AS timeUpdated,
 			token_count AS tokenCount
 		FROM word
-		WHERE content LIKE (? || '%')
-			AND language_id = ?
+		WHERE content LIKE (:content || '%')
+			AND language_id = :languageId
 			AND token_count > 1`,
 	//#endregion
 
@@ -308,7 +308,7 @@ const queries: { [key: string]: string } = {
 			meaning,
 			reading
 		FROM entry
-		WHERE word_id = ?
+		WHERE word_id = :wordId
 		ORDER BY position ASC`,
 	addEntry: `INSERT INTO entry (
 			word_id,
@@ -316,7 +316,7 @@ const queries: { [key: string]: string } = {
 			meaning,
 			reading
 		)
-		VALUES (?, ?, ?, ?)`,
+		VALUES (:wordId, :entryPosition, :meaning, :reading)`,
 	addEntriesInBatch: `INSERT INTO entry (
 			word_id,
 			position,
@@ -324,7 +324,7 @@ const queries: { [key: string]: string } = {
 			reading
 		)
 		VALUES %DYNAMIC%`,
-	deleteEntriesByWord: `DELETE FROM entry WHERE word_id = ?`,
+	deleteEntriesByWord: `DELETE FROM entry WHERE word_id = :wordId`,
 	//#endregion
 
 	//#region Status Log
@@ -354,7 +354,7 @@ const queries: { [key: string]: string } = {
 		JOIN word
 		ON word.id = ls.word_id
 		WHERE last_status > first_status
-			AND word.language_id = ?`,
+			AND word.language_id = :languageId`,
 	//#endregion
 
 	//#region Utils

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -22,10 +22,10 @@ const statisticsController = new StatisticsController();
 const router = express.Router();
 
 const errorWrapper = (handler: express.RequestHandler): express.RequestHandler => {
-	return async (req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> => {
+	return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
 		try
 		{
-			await handler(req, res, next);
+			handler(req, res, next);
 		}
 		catch (error)
 		{
@@ -39,24 +39,24 @@ const errorWrapper = (handler: express.RequestHandler): express.RequestHandler =
 router.get(
 	'/languages/',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json({ languages: await languagesController.getAllLanguages() });
+		(req: express.Request, res: express.Response): void => {
+			res.json({ languages: languagesController.getAllLanguages() });
 		}
 	)
 );
 router.get(
 	'/languages/:languageId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json(await languagesController.getLanguage(parseInt(req.params.languageId)));
+		(req: express.Request, res: express.Response): void => {
+			res.json(languagesController.getLanguage(parseInt(req.params.languageId)));
 		}
 	)
 );
 router.post(
 	'/languages/',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await languagesController.addLanguage(req.body.name, req.body.dictionaryUrl, req.body.shouldShowSpaces);
+		(req: express.Request, res: express.Response): void => {
+			languagesController.addLanguage(req.body.name, req.body.dictionaryUrl, req.body.shouldShowSpaces);
 			res.sendStatus(200);
 		}
 	)
@@ -64,8 +64,8 @@ router.post(
 router.delete(
 	'/languages/:languageId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await languagesController.deleteLanguage(parseInt(req.params.languageId));
+		(req: express.Request, res: express.Response): void => {
+			languagesController.deleteLanguage(parseInt(req.params.languageId));
 			res.sendStatus(200);
 		}
 	)
@@ -73,8 +73,8 @@ router.delete(
 router.patch(
 	'/languages/:languageId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await languagesController.editLanguage(
+		(req: express.Request, res: express.Response): void => {
+			languagesController.editLanguage(
 				parseInt(req.params.languageId),
 				req.body.name,
 				req.body.dictionaryUrl,
@@ -90,14 +90,14 @@ router.patch(
 router.get(
 	'/texts/',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
+		(req: express.Request, res: express.Response): void => {
 			if (req.query.languageId !== undefined)
 			{
-				res.json({ texts: await textsController.getTextsByLanguage(parseInt(req.query.languageId as string)) });
+				res.json({ texts: textsController.getTextsByLanguage(parseInt(req.query.languageId as string)) });
 			}
 			else
 			{
-				res.json({ texts: await textsController.getAllTexts() });
+				res.json({ texts: textsController.getAllTexts() });
 			}
 		}
 	)
@@ -105,11 +105,11 @@ router.get(
 router.get(
 	'/texts/:textId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
+		(req: express.Request, res: express.Response): void => {
 			res.json(
 				{
-					...await textsController.getText(parseInt(req.params.textId)),
-					numberOfPages: await textsController.getNumberOfPages(parseInt(req.params.textId)),
+					...textsController.getText(parseInt(req.params.textId)),
+					numberOfPages: textsController.getNumberOfPages(parseInt(req.params.textId)),
 				}
 			);
 		}
@@ -118,8 +118,8 @@ router.get(
 router.post(
 	'/texts/',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await textsController.addText(
+		(req: express.Request, res: express.Response): void => {
+			textsController.addText(
 				req.body.languageId,
 				req.body.title,
 				req.body.content,
@@ -133,8 +133,8 @@ router.post(
 router.delete(
 	'/texts/:textId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await textsController.deleteText(parseInt(req.params.textId));
+		(req: express.Request, res: express.Response): void => {
+			textsController.deleteText(parseInt(req.params.textId));
 			res.sendStatus(200);
 		}
 	)
@@ -142,8 +142,8 @@ router.delete(
 router.patch(
 	'/texts/:textId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await textsController.editText(
+		(req: express.Request, res: express.Response): void => {
+			textsController.editText(
 				req.body.languageId,
 				req.body.title,
 				req.body.sourceUrl,
@@ -164,26 +164,26 @@ router.patch(
 router.get(
 	'/texts/:textId/pages/',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json({ pages: await pagesController.getPagesByText(parseInt(req.params.textId)) });
+		(req: express.Request, res: express.Response): void => {
+			res.json({ pages: pagesController.getPagesByText(parseInt(req.params.textId)) });
 		}
 	)
 );
 router.get(
 	'/texts/:textId/pages/:pagePosition',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json(await pagesController.getPage(parseInt(req.params.textId), parseInt(req.params.pagePosition)));
+		(req: express.Request, res: express.Response): void => {
+			res.json(pagesController.getPage(parseInt(req.params.textId), parseInt(req.params.pagePosition)));
 		}
 	)
 );
 router.get(
 	'/texts/:textId/pages/:pagePosition/words',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
+		(req: express.Request, res: express.Response): void => {
 			res.json(
 				{
-					words: await pagesController.getWords(parseInt(req.params.textId), parseInt(req.params.pagePosition)),
+					words: pagesController.getWords(parseInt(req.params.textId), parseInt(req.params.pagePosition)),
 				}
 			);
 		}
@@ -192,8 +192,8 @@ router.get(
 router.patch(
 	'/texts/:textId/pages/:pagePosition',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await pagesController.editPage(
+		(req: express.Request, res: express.Response): void => {
+			pagesController.editPage(
 				parseInt(req.params.textId),
 				req.body.index,
 				req.body.content,
@@ -209,10 +209,10 @@ router.patch(
 router.get(
 	'/words/',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
+		(req: express.Request, res: express.Response): void => {
 			if (req.query.languageId !== undefined && req.query.content !== undefined)
 			{
-				const word = await wordsController.findWord(
+				const word = wordsController.findWord(
 					req.query.content as string,
 					parseInt(req.query.languageId as string)
 				);
@@ -236,16 +236,16 @@ router.get(
 router.get(
 	'/words/:wordId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json(await wordsController.getWord(parseInt(req.params.wordId)));
+		(req: express.Request, res: express.Response): void => {
+			res.json(wordsController.getWord(parseInt(req.params.wordId)));
 		}
 	)
 );
 router.post(
 	'/words/',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await wordsController.addWord(
+		(req: express.Request, res: express.Response): void => {
+			wordsController.addWord(
 				req.body.languageId,
 				req.body.content,
 				req.body.status,
@@ -261,8 +261,8 @@ router.post(
 router.post(
 	'/words/batch',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await wordsController.addWordsInBatch(
+		(req: express.Request, res: express.Response): void => {
+			wordsController.addWordsInBatch(
 				req.body.languageId,
 				req.body.contents,
 				req.body.status,
@@ -275,8 +275,8 @@ router.post(
 router.delete(
 	'/words/:wordId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await wordsController.deleteWord(parseInt(req.params.wordId));
+		(req: express.Request, res: express.Response): void => {
+			wordsController.deleteWord(parseInt(req.params.wordId));
 			res.sendStatus(200);
 		}
 	)
@@ -284,8 +284,8 @@ router.delete(
 router.patch(
 	'/words/:wordId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			await wordsController.editWord(
+		(req: express.Request, res: express.Response): void => {
+			wordsController.editWord(
 				req.body.languageId,
 				req.body.content,
 				req.body.status,
@@ -305,8 +305,8 @@ router.patch(
 router.get(
 	'/statistics/words-improved-count/:languageId',
 	errorWrapper(
-		async (req: express.Request, res: express.Response): Promise<void> => {
-			res.json(await statisticsController.getWordsImprovedCount(parseInt(req.params.languageId)));
+		(req: express.Request, res: express.Response): void => {
+			res.json(statisticsController.getWordsImprovedCount(parseInt(req.params.languageId)));
 		}
 	)
 );
@@ -373,7 +373,7 @@ router.patch(
 			res.sendStatus(200);
 		}
 	)
-)
+);
 //#endregion
 
 export { router };

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -189,20 +189,6 @@ router.get(
 		}
 	)
 );
-router.patch(
-	'/texts/:textId/pages/:pagePosition',
-	errorWrapper(
-		(req: express.Request, res: express.Response): void => {
-			pagesController.editPage(
-				parseInt(req.params.textId),
-				req.body.index,
-				req.body.content,
-				parseInt(req.params.pagePosition)
-			);
-			res.sendStatus(200);
-		}
-	)
-);
 //#endregion
 
 //#region Words


### PR DESCRIPTION
While [sqlite3](https://www.npmjs.com/package/sqlite3) is the most popular of the two, [better-sqlite3](https://www.npmjs.com/package/better-sqlite3) is claimed to be both faster and simpler to use.

The main difference is the former interacts with the SQLite database in an asynchronous manner, while the latter does so synchronously. For Irakur's use case, this is not an issue, since only a single user will use the database in principle; even if this weren't the case, the `better-sqlite3` team claim that even with synchronous bindings they manage to provide better concurrency.

Additionally, `better-sqlite3` allows `:AAAA` syntax for binding parameters, which I couldn't get working in `sqlite3`.

As a downside, `better-sqlite3` doesn't ([nor does it intend to](https://github.com/WiseLibs/better-sqlite3/issues/932)) support boolean inputs to queries, so the casting needs to be done manually in our code. This isn't a huge problem though, only about 10 additional lines were necessary to work around this.

The main advantage for us is the ability to define SQLite user functions in JavaScript. Specifically, we will need the `regexp` user function in the following pull request, to replace the `GLOB` operator we are currently using in the `findWordsInBatch` query. While I believe defining user functions is possible in `sqlite3` as well, it is definitely not as straight-forward as it'll be with the new library.

Finally, the `editPage` function was removed, since it wasn't being used and it would've been pointless to adapt its code to the current `databaseManager`'s syntax.