### PR TITLE
Language templates

### DIFF
--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -26,7 +26,8 @@ class BackendConnector
 		sentenceDelimiters: string,
 		whitespaces: string,
 		intrawordPunctuation: string,
-		templateCode: string
+		templateCode: string,
+		scriptName: string
 	): Promise<boolean>
 	{
 		const response: Response = await fetch(

--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -25,7 +25,8 @@ class BackendConnector
 		alphabet: string,
 		sentenceDelimiters: string,
 		whitespaces: string,
-		intrawordPunctuation: string
+		intrawordPunctuation: string,
+		templateCode: string
 	): Promise<boolean>
 	{
 		const response: Response = await fetch(
@@ -44,6 +45,7 @@ class BackendConnector
 						sentenceDelimiters,
 						whitespaces,
 						intrawordPunctuation,
+						templateCode,
 					}
 				),
 			}

--- a/client/src/backend-connector/backend-connector.ts
+++ b/client/src/backend-connector/backend-connector.ts
@@ -47,6 +47,7 @@ class BackendConnector
 						whitespaces,
 						intrawordPunctuation,
 						templateCode,
+						scriptName,
 					}
 				),
 			}

--- a/client/src/components/add-language-form/add-language-form.tsx
+++ b/client/src/components/add-language-form/add-language-form.tsx
@@ -74,7 +74,8 @@ const AddLanguageForm = (
 			form.get('sentenceDelimiters') as string,
 			form.get('whitespaces') as string,
 			form.get('intrawordPunctuation') as string,
-			(targetLanguageName || '') + ':' + (auxiliaryLanguageName || '')
+			(targetLanguageName || '') + ':' + (auxiliaryLanguageName || ''),
+			form.get('scriptName') as string
 		);
 
 		if (wasAdded)
@@ -126,8 +127,10 @@ const AddLanguageForm = (
 				<br />
 				<br />
 
-				<label htmlFor="script">Script</label>
+				<label htmlFor="scriptName">Script</label>
 				<select
+					name="scriptName"
+					id="scriptName"
 					defaultValue={languageTemplate.script || 'Latin'}
 					onChange={
 						(event): void => {

--- a/client/src/components/add-language-form/add-language-form.tsx
+++ b/client/src/components/add-language-form/add-language-form.tsx
@@ -73,7 +73,8 @@ const AddLanguageForm = (
 			form.get('alphabet') as string,
 			form.get('sentenceDelimiters') as string,
 			form.get('whitespaces') as string,
-			form.get('intrawordPunctuation') as string
+			form.get('intrawordPunctuation') as string,
+			(targetLanguageName || '') + ':' + (auxiliaryLanguageName || '')
 		);
 
 		if (wasAdded)

--- a/client/src/components/add-language-form/add-language-form.tsx
+++ b/client/src/components/add-language-form/add-language-form.tsx
@@ -1,0 +1,111 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import React, { useState } from 'react';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+
+import { backendConnector } from '../../backend-connector';
+import { getPartialTemplate } from '../../language-templates';
+
+const AddLanguageForm = (
+	{
+		targetLanguageName,
+		auxiliaryLanguageName
+	}: {
+		targetLanguageName: string,
+		auxiliaryLanguageName: string
+	}
+): JSX.Element => {
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+	const languageTemplate = getPartialTemplate(targetLanguageName, auxiliaryLanguageName);
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+		event.preventDefault();
+
+		setIsSubmitting(true);
+
+		if (event.target === null)
+		{
+			return;
+		}
+
+		const form = new FormData(event.target as HTMLFormElement);
+
+		const wasAdded: boolean = await backendConnector.addLanguage(
+			form.get('name') as string,
+			form.get('dictionaryUrl') as string,
+			(form.get('shouldShowSpaces') as string) === 'on',
+			form.get('alphabet') as string,
+			form.get('sentenceDelimiters') as string,
+			form.get('whitespaces') as string,
+			form.get('intrawordPunctuation') as string
+		);
+
+		if (wasAdded)
+		{
+			window.location.href = '/languages';
+		}
+
+		setIsSubmitting(false);
+	};
+
+	return (
+		<HelmetProvider>
+			<Helmet>
+				<title>Irakur - Add language</title>
+			</Helmet>
+			<h1>Irakur - Add language</h1>
+			<form method="post" onSubmit={handleSubmit}>
+				<label htmlFor="name">Name</label>
+				<input type="text" name="name" id="name" defaultValue={languageTemplate.translatedName}/>
+				<br />
+				<label htmlFor="dictionaryUrl">Dictionary URL</label>
+				<input
+					type="text"
+					name="dictionaryUrl"
+					id="dictionaryUrl"
+					defaultValue={languageTemplate.dictionaryUrl}
+				/>
+				<br />
+				<label htmlFor="shouldShowSpaces">Show spaces</label>
+				<input
+					type="checkbox"
+					name="shouldShowSpaces"
+					id="shouldShowSpaces"
+					defaultChecked={languageTemplate.shouldShowSpaces}
+				/>
+				<br />
+				<label htmlFor="alphabet">Alphabet</label>
+				<input type="text" name="alphabet" id="alphabet" defaultValue={languageTemplate.alphabet}/>
+				<br />
+				<label htmlFor="sentenceDelimiters">Sentence delimiters</label>
+				<input
+					type="text"
+					name="sentenceDelimiters"
+					id="sentenceDelimiters"
+					defaultValue={languageTemplate.sentenceDelimiters}
+				/>
+				<br />
+				<label htmlFor="whitespaces">Whitespaces</label>
+				<input type="text" name="whitespaces" id="whitespaces" defaultValue={languageTemplate.whitespaces}/>
+				<br />
+				<label htmlFor="intrawordPunctuation">Intraword punctuation</label>
+				<input
+					type="text"
+					name="intrawordPunctuation"
+					id="intrawordPunctuation"
+					defaultValue={languageTemplate.intrawordPunctuation}
+				/>
+				<br />
+
+				<button type="submit" disabled={isSubmitting}>Add</button>
+			</form>
+		</HelmetProvider>
+	);
+};
+
+export { AddLanguageForm };

--- a/client/src/components/add-language-form/add-language-form.tsx
+++ b/client/src/components/add-language-form/add-language-form.tsx
@@ -21,13 +21,13 @@ const scripts: Record<string, Script> = {
 	'Latin': {
 		alphabet: '[a-zA-Z\\u00C0-\\u024F\\u1E00-\\u1EFF]',
 		sentenceDelimiters: '[!.?…]',
-		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		whitespaces: '[\\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
 	},
 	'Japanese': {
 		alphabet: '[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]+|[々〆〤ヶ]+',
 		sentenceDelimiters: '[!.?…。．？｡！]',
-		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		whitespaces: '[\\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
 	},
 };

--- a/client/src/components/add-language-form/index.ts
+++ b/client/src/components/add-language-form/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+export * from './add-language-form';

--- a/client/src/components/language-wizard/index.ts
+++ b/client/src/components/language-wizard/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+export * from './language-wizard';

--- a/client/src/components/language-wizard/language-wizard.tsx
+++ b/client/src/components/language-wizard/language-wizard.tsx
@@ -40,7 +40,7 @@ const LanguageWizard = (
 			>
 				<option value="">Configure it yourself</option>
 				{
-					Object.keys(targetLanguages).map(
+					Object.keys(targetLanguages).sort().map(
 						(targetLanguage: string) => (
 							<option
 								key={targetLanguage}
@@ -71,7 +71,7 @@ const LanguageWizard = (
 			>
 				<option value="">Configure it yourself</option>
 				{
-					(targetLanguage !== '') && Object.keys(targetLanguages[targetLanguage].templates).map(
+					(targetLanguage !== '') && Object.keys(targetLanguages[targetLanguage].templates).sort().map(
 						(auxiliaryLanguage: string) => (
 							<option
 								key={auxiliaryLanguage}

--- a/client/src/components/language-wizard/language-wizard.tsx
+++ b/client/src/components/language-wizard/language-wizard.tsx
@@ -1,0 +1,106 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+import { useState } from 'react';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+
+import { targetLanguages } from '../../language-templates';
+
+const LanguageWizard = (
+	{
+		finishWizard
+	}: {
+		finishWizard: (targetLanguageName: string, auxiliaryLanguageName: string) => void
+	}
+): JSX.Element => {
+	const [targetLanguage, setTargetLanguage] = useState<string>('');
+	const [auxiliaryLanguage, setAuxiliaryLanguage] = useState<string>('');
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+	const handleSubmit = (): void => {
+		setIsSubmitting(true);
+
+		finishWizard(targetLanguage, auxiliaryLanguage);
+	};
+
+	return (
+		<HelmetProvider>
+			<Helmet>
+				<title>Irakur - Language wizard</title>
+			</Helmet>
+			<h1>Irakur - Language wizard</h1>
+
+			<p>What language do you want to learn?</p>
+			<select
+				value={targetLanguage || ''}
+				onChange={(event): void => setTargetLanguage(event.target.value)}
+			>
+				<option value="">Configure it yourself</option>
+				{
+					Object.keys(targetLanguages).map(
+						(targetLanguage: string) => (
+							<option
+								key={targetLanguage}
+								value={targetLanguage}
+								onClick={
+									(): void => {
+										if (targetLanguage === '') {
+											handleSubmit();
+										}
+										setTargetLanguage(targetLanguage);
+									}
+								}
+							>
+								{targetLanguage}
+							</option>
+						)
+					)
+				}
+			</select>
+			<br />
+			<br />
+
+			<p>What language do you already know?</p>
+			<select
+				defaultValue={auxiliaryLanguage || ''}
+				disabled={targetLanguage === ''}
+				onChange={(event): void => setAuxiliaryLanguage(event.target.value)}
+			>
+				<option value="">Configure it yourself</option>
+				{
+					(targetLanguage !== '') && Object.keys(targetLanguages[targetLanguage].templates).map(
+						(auxiliaryLanguage: string) => (
+							<option
+								key={auxiliaryLanguage}
+								value={auxiliaryLanguage}
+								onClick={
+									(): void => {
+										setAuxiliaryLanguage(auxiliaryLanguage);
+									}
+								}
+							>
+								{auxiliaryLanguage}
+							</option>
+						)
+					)
+				}
+			</select>
+			<br />
+			<br />
+			<br />
+
+			<button
+				type="submit"
+				disabled={isSubmitting}
+				onClick={handleSubmit}
+			>
+				Submit
+			</button>
+		</HelmetProvider>
+	);
+};
+
+export { LanguageWizard };

--- a/client/src/components/language-wizard/language-wizard.tsx
+++ b/client/src/components/language-wizard/language-wizard.tsx
@@ -13,7 +13,7 @@ const LanguageWizard = (
 	{
 		finishWizard
 	}: {
-		finishWizard: (targetLanguageName: string, auxiliaryLanguageName: string) => void
+		finishWizard: (targetLanguageName: string | null, auxiliaryLanguageName: string | null) => void
 	}
 ): JSX.Element => {
 	const [targetLanguage, setTargetLanguage] = useState<string>('');
@@ -23,7 +23,10 @@ const LanguageWizard = (
 	const handleSubmit = (): void => {
 		setIsSubmitting(true);
 
-		finishWizard(targetLanguage, auxiliaryLanguage);
+		finishWizard(
+			targetLanguage === '' ? null : targetLanguage,
+			auxiliaryLanguage === '' ? null : auxiliaryLanguage
+		);
 	};
 
 	return (

--- a/client/src/components/language-wizard/language-wizard.tsx
+++ b/client/src/components/language-wizard/language-wizard.tsx
@@ -85,7 +85,11 @@ const LanguageWizard = (
 									}
 								}
 							>
-								{auxiliaryLanguage}
+								{
+									auxiliaryLanguage === targetLanguage
+										? `${auxiliaryLanguage} (Monolingual)`
+										: auxiliaryLanguage
+								}
 							</option>
 						)
 					)

--- a/client/src/components/reader/reader.tsx
+++ b/client/src/components/reader/reader.tsx
@@ -498,8 +498,9 @@ const Reader = (
 		{
 			renderedElement = <br key={word.index} data-index={word.index} style={{ marginBottom: "1rem" }}/>;
 		}
-		else if (new RegExp(languageData.whitespaces, 'ug').test(word.content))
+		else if (word.type === 'whitespace')
 		{
+			console.log("Regex: " + languageData.whitespaces + "\tContent: " + word.content);
 			renderedElement = whitespaceRender(word);
 		}
 		else if (word.type === 'punctuation')

--- a/client/src/language-templates/index.ts
+++ b/client/src/language-templates/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+export * from './language-templates';

--- a/client/src/language-templates/language-templates.ts
+++ b/client/src/language-templates/language-templates.ts
@@ -16,6 +16,7 @@ type BaseProperties = {
 	whitespaces: string;
 	intrawordPunctuation: string;
 	shouldShowSpaces: boolean;
+	script: string;
 };
 
 type LanguageTemplate = BaseProperties & SpecificProperties;
@@ -34,6 +35,7 @@ const targetLanguages: TargetLanguageRecord = {
 		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
 		shouldShowSpaces: true,
+		script: 'Latin',
 		templates: {
 			English: {
 				translatedName: 'English',
@@ -57,6 +59,7 @@ const targetLanguages: TargetLanguageRecord = {
 		sentenceDelimiters: '[!.?…。．？｡！]',
 		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
+		script: 'Japanese',
 		templates: {
 			Japanese: {
 				translatedName: '日本語',
@@ -74,11 +77,12 @@ const targetLanguages: TargetLanguageRecord = {
 	},
 	Spanish: {
 		nativeName: 'Español',
-		alphabet: '[a-zA-ZáéíóúÁÉÍÓÚüÜñÑçÇ]',
+		alphabet: '[a-zA-Z\\u00C0-\\u024F\\u1E00-\\u1EFF]',
 		sentenceDelimiters: '[!.?…]',
 		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
 		shouldShowSpaces: true,
+		script: 'Latin',
 		templates: {
 			Spanish: {
 				translatedName: 'Español',
@@ -96,17 +100,22 @@ const targetLanguages: TargetLanguageRecord = {
 	},
 };
 
-const getPartialTemplate = (targetLanguageName: string, auxiliaryLanguageName: string): Partial<LanguageTemplate> => {
-	console.log(targetLanguageName, auxiliaryLanguageName);
-	if (targetLanguageName === '')
+const getPartialTemplate = (
+	targetLanguageName: string | null,
+	auxiliaryLanguageName: string | null
+): Partial<LanguageTemplate> => {
+	if (targetLanguageName === null || targetLanguageName === '')
 	{
 		return {};
 	}
+
 	const { templates, ...baseProperties } = targetLanguages[targetLanguageName];
-	if (auxiliaryLanguageName === '')
+
+	if (auxiliaryLanguageName === null || auxiliaryLanguageName === '')
 	{
 		return baseProperties;
 	}
+
 	const specificProperties = targetLanguages[targetLanguageName].templates[auxiliaryLanguageName];
 
 	return {

--- a/client/src/language-templates/language-templates.ts
+++ b/client/src/language-templates/language-templates.ts
@@ -89,11 +89,11 @@ const targetLanguages: TargetLanguageRecord = {
 				dictionaryUrl: 'https://www.wordreference.com/definicion/%s',
 			},
 			English: {
-				translatedName: 'Español',
+				translatedName: 'Spanish',
 				dictionaryUrl: 'https://www.wordreference.com/es/en/translation.asp?spen=%s',
 			},
 			Japanese: {
-				translatedName: 'Español',
+				translatedName: 'スペイン語',
 				dictionaryUrl: 'https://aulex.org/japones/?busca=%s',
 			},
 		},

--- a/client/src/language-templates/language-templates.ts
+++ b/client/src/language-templates/language-templates.ts
@@ -96,4 +96,23 @@ const targetLanguages: TargetLanguageRecord = {
 	},
 };
 
-export { getTemplate, targetLanguages };
+const getPartialTemplate = (targetLanguageName: string, auxiliaryLanguageName: string): Partial<LanguageTemplate> => {
+	console.log(targetLanguageName, auxiliaryLanguageName);
+	if (targetLanguageName === '')
+	{
+		return {};
+	}
+	const { templates, ...baseProperties } = targetLanguages[targetLanguageName];
+	if (auxiliaryLanguageName === '')
+	{
+		return baseProperties;
+	}
+	const specificProperties = targetLanguages[targetLanguageName].templates[auxiliaryLanguageName];
+
+	return {
+		...baseProperties,
+		...specificProperties,
+	};
+};
+
+export { getPartialTemplate, targetLanguages };

--- a/client/src/language-templates/language-templates.ts
+++ b/client/src/language-templates/language-templates.ts
@@ -32,7 +32,7 @@ const targetLanguages: TargetLanguageRecord = {
 		nativeName: 'English',
 		alphabet: '[a-zA-Z\\u00C0-\\u024F\\u1E00-\\u1EFF]',
 		sentenceDelimiters: '[!.?…]',
-		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		whitespaces: '[\\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
 		shouldShowSpaces: true,
 		script: 'Latin',
@@ -57,7 +57,7 @@ const targetLanguages: TargetLanguageRecord = {
 		shouldShowSpaces: true, // Since U+200B will be used by default to represent word breaks,
 								// there's no need to hide whitespaces in general.
 		sentenceDelimiters: '[!.?…。．？｡！]',
-		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		whitespaces: '[\\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
 		script: 'Japanese',
 		templates: {
@@ -79,7 +79,7 @@ const targetLanguages: TargetLanguageRecord = {
 		nativeName: 'Español',
 		alphabet: '[a-zA-Z\\u00C0-\\u024F\\u1E00-\\u1EFF]',
 		sentenceDelimiters: '[!.?…]',
-		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		whitespaces: '[\\s\\u0085\\u2001-\\u2009\\u200B]',
 		intrawordPunctuation: '',
 		shouldShowSpaces: true,
 		script: 'Latin',

--- a/client/src/language-templates/language-templates.ts
+++ b/client/src/language-templates/language-templates.ts
@@ -4,101 +4,96 @@
  * Licensed under version 3 of the GNU Affero General Public License
  */
 
-type LanguageTemplate = {
-	// General properties of target language:
+type SpecificProperties = {
+	translatedName: string;
+	dictionaryUrl: string;
+};
+
+type BaseProperties = {
 	nativeName: string;
 	alphabet: string;
 	sentenceDelimiters: string;
 	whitespaces: string;
 	intrawordPunctuation: string;
 	shouldShowSpaces: boolean;
-	// Properties of specific templates:
-	translatedName: string;
-	dictionaryUrl: string;
 };
 
-type TemplateCollection = Record<string, Record<string, LanguageTemplate>>;
+type LanguageTemplate = BaseProperties & SpecificProperties;
 
-const languageTemplates: TemplateCollection = {
+type TargetLanguage = BaseProperties & {
+	templates: Record<string, SpecificProperties>;
+};
+
+type TargetLanguageRecord = Record<string, TargetLanguage>;
+
+const targetLanguages: TargetLanguageRecord = {
 	English: {
-		English: {
-			nativeName: 'English',
-			alphabet: '[a-zA-Z\\u00C0-\\u024F\\u1E00-\\u1EFF]',
-			sentenceDelimiters: '[!.?…]',
-			whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
-			intrawordPunctuation: '',
-			shouldShowSpaces: true,
-			translatedName: 'English',
-			dictionaryUrl: 'https://www.dictionary.com/browse/%s',
+		nativeName: 'English',
+		alphabet: '[a-zA-Z\\u00C0-\\u024F\\u1E00-\\u1EFF]',
+		sentenceDelimiters: '[!.?…]',
+		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		intrawordPunctuation: '',
+		shouldShowSpaces: true,
+		templates: {
+			English: {
+				translatedName: 'English',
+				dictionaryUrl: 'https://www.dictionary.com/browse/%s',
+			},
+			Spanish: {
+				translatedName: 'Inglés',
+				dictionaryUrl: 'https://www.wordreference.com/es/translation.asp?tranword=%s',
+			},
+			Japanese: {
+				translatedName: '英語',
+				dictionaryUrl: 'https://www.wordreference.com/enja/%s',
+			},
 		},
 	},
 	Japanese: {
-		Japanese: {
-			nativeName: '日本語',
-			alphabet: '[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]+|[々〆〤ヶ]+',
-			shouldShowSpaces: true, // Since U+200B will be used by default to represent word breaks,
-			                        // there's no need to hide whitespaces in general.
-			sentenceDelimiters: '[!.?…。．？｡！]',
-			whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
-			intrawordPunctuation: '',
-			translatedName: '日本語',
-			dictionaryUrl: 'https://dictionary.goo.ne.jp/srch/jn/%s/m0u/'
+		nativeName: '日本語',
+		alphabet: '[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]+|[々〆〤ヶ]+',
+		shouldShowSpaces: true, // Since U+200B will be used by default to represent word breaks,
+								// there's no need to hide whitespaces in general.
+		sentenceDelimiters: '[!.?…。．？｡！]',
+		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		intrawordPunctuation: '',
+		templates: {
+			Japanese: {
+				translatedName: '日本語',
+				dictionaryUrl: 'https://dictionary.goo.ne.jp/srch/jn/%s/m0u/'
+			},
+			English: {
+				translatedName: 'Japanese',
+				dictionaryUrl: 'https://jisho.org/search/%s',
+			},
+			Spanish: {
+				translatedName: 'Japonés',
+				dictionaryUrl: 'https://aulex.org/japones/?busca=%s',
+			},
+		}
+	},
+	Spanish: {
+		nativeName: 'Español',
+		alphabet: '[a-zA-ZáéíóúÁÉÍÓÚüÜñÑçÇ]',
+		sentenceDelimiters: '[!.?…]',
+		whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+		intrawordPunctuation: '',
+		shouldShowSpaces: true,
+		templates: {
+			Spanish: {
+				translatedName: 'Español',
+				dictionaryUrl: 'https://www.wordreference.com/definicion/%s',
+			},
+			English: {
+				translatedName: 'Español',
+				dictionaryUrl: 'https://www.wordreference.com/es/en/translation.asp?spen=%s',
+			},
+			Japanese: {
+				translatedName: 'Español',
+				dictionaryUrl: 'https://aulex.org/japones/?busca=%s',
+			},
 		},
 	},
-	Spanish: {
-		Spanish: {
-			nativeName: 'Español',
-			alphabet: '[a-zA-ZáéíóúÁÉÍÓÚüÜñÑçÇ]',
-			sentenceDelimiters: '[!.?…]',
-			whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
-			intrawordPunctuation: '',
-			shouldShowSpaces: true,
-			translatedName: 'Español',
-			dictionaryUrl: 'https://www.wordreference.com/definicion/%s',
-		},
-	},
 };
 
-languageTemplates.English = {
-	...languageTemplates.English,
-	Spanish: {
-		...languageTemplates.English.English,
-		translatedName: 'Inglés',
-		dictionaryUrl: 'https://www.wordreference.com/es/translation.asp?tranword=%s',
-	},
-	Japanese: {
-		...languageTemplates.English.English,
-		translatedName: '英語',
-		dictionaryUrl: 'https://www.wordreference.com/enja/%s',
-	},
-};
-
-languageTemplates.Japanese = {
-	...languageTemplates.Japanese,
-	English: {
-		...languageTemplates.Japanese.Japanese,
-		translatedName: 'Japanese',
-		dictionaryUrl: 'https://jisho.org/search/%s',
-	},
-	Spanish: {
-		...languageTemplates.Japanese.Japanese,
-		translatedName: 'Japonés',
-		dictionaryUrl: 'https://aulex.org/japones/?busca=%s',
-	},
-};
-
-languageTemplates.Spanish = {
-	...languageTemplates.Spanish,
-	English: {
-		...languageTemplates.Spanish.Spanish,
-		translatedName: 'Español',
-		dictionaryUrl: 'https://www.wordreference.com/es/en/translation.asp?spen=%s',
-	},
-	Japanese: {
-		...languageTemplates.Spanish.Spanish,
-		translatedName: 'Español',
-		dictionaryUrl: 'https://aulex.org/japones/?busca=%s',
-	},
-};
-
-export { languageTemplates };
+export { getTemplate, targetLanguages };

--- a/client/src/language-templates/language-templates.ts
+++ b/client/src/language-templates/language-templates.ts
@@ -1,0 +1,104 @@
+/*
+ * Irakur - Learn languages through immersion
+ * Copyright (C) 2023-2024 Ander Aginaga San Sebastián (a.k.a. Laquin or Laquinh)
+ * Licensed under version 3 of the GNU Affero General Public License
+ */
+
+type LanguageTemplate = {
+	// General properties of target language:
+	nativeName: string;
+	alphabet: string;
+	sentenceDelimiters: string;
+	whitespaces: string;
+	intrawordPunctuation: string;
+	shouldShowSpaces: boolean;
+	// Properties of specific templates:
+	translatedName: string;
+	dictionaryUrl: string;
+};
+
+type TemplateCollection = Record<string, Record<string, LanguageTemplate>>;
+
+const languageTemplates: TemplateCollection = {
+	English: {
+		English: {
+			nativeName: 'English',
+			alphabet: '[a-zA-Z\\u00C0-\\u024F\\u1E00-\\u1EFF]',
+			sentenceDelimiters: '[!.?…]',
+			whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+			intrawordPunctuation: '',
+			shouldShowSpaces: true,
+			translatedName: 'English',
+			dictionaryUrl: 'https://www.dictionary.com/browse/%s',
+		},
+	},
+	Japanese: {
+		Japanese: {
+			nativeName: '日本語',
+			alphabet: '[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]+|[々〆〤ヶ]+',
+			shouldShowSpaces: true, // Since U+200B will be used by default to represent word breaks,
+			                        // there's no need to hide whitespaces in general.
+			sentenceDelimiters: '[!.?…。．？｡！]',
+			whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+			intrawordPunctuation: '',
+			translatedName: '日本語',
+			dictionaryUrl: 'https://dictionary.goo.ne.jp/srch/jn/%s/m0u/'
+		},
+	},
+	Spanish: {
+		Spanish: {
+			nativeName: 'Español',
+			alphabet: '[a-zA-ZáéíóúÁÉÍÓÚüÜñÑçÇ]',
+			sentenceDelimiters: '[!.?…]',
+			whitespaces: '[\s\\u0085\\u2001-\\u2009\\u200B]',
+			intrawordPunctuation: '',
+			shouldShowSpaces: true,
+			translatedName: 'Español',
+			dictionaryUrl: 'https://www.wordreference.com/definicion/%s',
+		},
+	},
+};
+
+languageTemplates.English = {
+	...languageTemplates.English,
+	Spanish: {
+		...languageTemplates.English.English,
+		translatedName: 'Inglés',
+		dictionaryUrl: 'https://www.wordreference.com/es/translation.asp?tranword=%s',
+	},
+	Japanese: {
+		...languageTemplates.English.English,
+		translatedName: '英語',
+		dictionaryUrl: 'https://www.wordreference.com/enja/%s',
+	},
+};
+
+languageTemplates.Japanese = {
+	...languageTemplates.Japanese,
+	English: {
+		...languageTemplates.Japanese.Japanese,
+		translatedName: 'Japanese',
+		dictionaryUrl: 'https://jisho.org/search/%s',
+	},
+	Spanish: {
+		...languageTemplates.Japanese.Japanese,
+		translatedName: 'Japonés',
+		dictionaryUrl: 'https://aulex.org/japones/?busca=%s',
+	},
+};
+
+languageTemplates.Spanish = {
+	...languageTemplates.Spanish,
+	English: {
+		...languageTemplates.Spanish.Spanish,
+		translatedName: 'Español',
+		dictionaryUrl: 'https://www.wordreference.com/es/en/translation.asp?spen=%s',
+	},
+	Japanese: {
+		...languageTemplates.Spanish.Spanish,
+		translatedName: 'Español',
+		dictionaryUrl: 'https://aulex.org/japones/?busca=%s',
+	},
+};
+
+export { languageTemplates };

--- a/client/src/pages/add-language/add-language.tsx
+++ b/client/src/pages/add-language/add-language.tsx
@@ -4,77 +4,37 @@
  * Licensed under version 3 of the GNU Affero General Public License
  */
 
-import React, { useState } from 'react';
-import { Helmet, HelmetProvider } from 'react-helmet-async';
+import { useState } from 'react';
 
-import { backendConnector } from '../../backend-connector';
+import { AddLanguageForm } from '../../components/add-language-form';
+import { LanguageWizard } from '../../components/language-wizard';
 
 const AddLanguage = (): JSX.Element => {
-	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+	const [targetLanguageName, setTargetLanguageName] = useState<string | null>(null);
+	const [auxiliaryLanguageName, setAuxiliaryLanguageName] = useState<string | null>(null);
+	const [isWizardDone, setIsWizardDone] = useState<boolean>(false);
 
-	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
-		event.preventDefault();
-
-		setIsSubmitting(true);
-
-		if (event.target === null)
-		{
-			return;
-		}
-
-		const form = new FormData(event.target as HTMLFormElement);
-
-		const wasAdded: boolean = await backendConnector.addLanguage(
-			form.get('name') as string,
-			form.get('dictionaryUrl') as string,
-			(form.get('shouldShowSpaces') as string) === 'on',
-			form.get('alphabet') as string,
-			form.get('sentenceDelimiters') as string,
-			form.get('whitespaces') as string,
-			form.get('intrawordPunctuation') as string
+	if (!isWizardDone)
+	{
+		return <LanguageWizard
+			finishWizard={
+				(targetLanguageName: string, auxiliaryLanguageName: string): void => {
+					setTargetLanguageName(targetLanguageName);
+					setAuxiliaryLanguageName(auxiliaryLanguageName);
+					setIsWizardDone(true);
+				}
+			}
+		/>;
+	}
+	else
+	{
+		return (
+			<AddLanguageForm
+				targetLanguageName={targetLanguageName || ''}
+				auxiliaryLanguageName={auxiliaryLanguageName || ''}
+			/>
 		);
-
-		if (wasAdded)
-		{
-			window.location.href = '/languages';
-		}
-
-		setIsSubmitting(false);
-	};
-
-	return (
-		<HelmetProvider>
-			<Helmet>
-				<title>Irakur - Add language</title>
-			</Helmet>
-			<h1>Irakur - Add language</h1>
-			<form method="post" onSubmit={handleSubmit}>
-				<label htmlFor="name">Name</label>
-				<input type="text" name="name" id="name" />
-				<br />
-				<label htmlFor="dictionaryUrl">Dictionary URL</label>
-				<input type="text" name="dictionaryUrl" id="dictionaryUrl" />
-				<br />
-				<label htmlFor="shouldShowSpaces">Show spaces</label>
-				<input type="checkbox" name="shouldShowSpaces" id="shouldShowSpaces" />
-				<br />
-				<label htmlFor="alphabet">Alphabet</label>
-				<input type="text" name="alphabet" id="alphabet" />
-				<br />
-				<label htmlFor="sentenceDelimiters">Sentence delimiters</label>
-				<input type="text" name="sentenceDelimiters" id="sentenceDelimiters" />
-				<br />
-				<label htmlFor="whitespaces">Whitespaces</label>
-				<input type="text" name="whitespaces" id="whitespaces" />
-				<br />
-				<label htmlFor="intrawordPunctuation">Intraword punctuation</label>
-				<input type="text" name="intrawordPunctuation" id="intrawordPunctuation" />
-				<br />
-
-				<button type="submit" disabled={isSubmitting}>Add</button>
-			</form>
-		</HelmetProvider>
-	);
+	}
 };
 
 export { AddLanguage };

--- a/client/src/pages/add-language/add-language.tsx
+++ b/client/src/pages/add-language/add-language.tsx
@@ -18,7 +18,7 @@ const AddLanguage = (): JSX.Element => {
 	{
 		return <LanguageWizard
 			finishWizard={
-				(targetLanguageName: string, auxiliaryLanguageName: string): void => {
+				(targetLanguageName: string | null, auxiliaryLanguageName: string | null): void => {
 					setTargetLanguageName(targetLanguageName);
 					setAuxiliaryLanguageName(auxiliaryLanguageName);
 					setIsWizardDone(true);

--- a/common/types.ts
+++ b/common/types.ts
@@ -13,6 +13,7 @@ type Language = {
 	sentenceDelimiters: string;
 	whitespaces: string;
 	intrawordPunctuation: string;
+	templateCode: string;
 };
 
 type Text = {

--- a/common/types.ts
+++ b/common/types.ts
@@ -14,6 +14,7 @@ type Language = {
 	whitespaces: string;
 	intrawordPunctuation: string;
 	templateCode: string;
+	scriptName: string;
 };
 
 type Text = {

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -31,7 +31,7 @@ const tokenizeString = (str: string, alphabet: string, intrawordPunctuation: str
 		"("
 			+ intrawordPunctuation + "(?!" + alphabet + ")"
 			+ "|(?<!"+ alphabet + ")" + intrawordPunctuation
-			+ "|(?!" + alphabet + "|" + intrawordPunctuation + ").|\n"
+			+ "|(?!" + alphabet + (intrawordPunctuation === '' ? '' : ('|' + intrawordPunctuation)) + ").|\n"
 			+ ")",
 		'u'
 	);

--- a/server/src/controllers/languages-controller.ts
+++ b/server/src/controllers/languages-controller.ts
@@ -18,7 +18,8 @@ class LanguagesController
 		sentenceDelimiters: string,
 		whitespaces: string,
 		intrawordPunctuation: string,
-		templateCode: string
+		templateCode: string,
+		scriptName: string
 	): void
 	{
 		databaseManager.runQuery(
@@ -32,6 +33,7 @@ class LanguagesController
 				whitespaces,
 				intrawordPunctuation,
 				templateCode,
+				scriptName,
 			}
 		);
 	}

--- a/server/src/controllers/languages-controller.ts
+++ b/server/src/controllers/languages-controller.ts
@@ -17,7 +17,8 @@ class LanguagesController
 		alphabet: string,
 		sentenceDelimiters: string,
 		whitespaces: string,
-		intrawordPunctuation: string
+		intrawordPunctuation: string,
+		templateCode: string
 	): void
 	{
 		databaseManager.runQuery(
@@ -30,6 +31,7 @@ class LanguagesController
 				sentenceDelimiters,
 				whitespaces,
 				intrawordPunctuation,
+				templateCode,
 			}
 		);
 	}

--- a/server/src/controllers/pages-controller.ts
+++ b/server/src/controllers/pages-controller.ts
@@ -61,6 +61,7 @@ class PagesController
 		);
 
 		const decodedAlphabet: string = decodeURI(language.alphabet);
+		const decodedWhitespaces: string = decodeURI(language.whitespaces);
 
 		const tokens: string[] = tokenizeString(page.content, language.alphabet, language.intrawordPunctuation);
 		
@@ -80,6 +81,7 @@ class PagesController
 			{
 				languageId: language.id,
 				alphabet: decodedAlphabet,
+				whitespaces: decodedWhitespaces,
 			}
 		);
 

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -272,9 +272,10 @@ const queries: Record<string, string> = {
 			input_words.content AS content,
 			status,
 			CASE 
-				WHEN
-					input_words.content REGEXP :alphabet
-				THEN 'word'
+				WHEN input_words.content REGEXP :alphabet
+					THEN 'word'
+				WHEN input_words.content REGEXP :whitespaces
+					THEN 'whitespace'
 				ELSE 'punctuation'
 			END AS type,
 			EXISTS (

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -20,6 +20,7 @@ const queries: Record<string, string> = {
 		sentence_delimiters TEXT NOT NULL,
 		whitespaces TEXT NOT NULL,
 		intraword_punctuation TEXT NOT NULL,
+		template_code TEXT NOT NULL,
 		CONSTRAINT pk__language__id PRIMARY KEY (id),
 		CONSTRAINT uq__language__name UNIQUE (name)
 	)`,
@@ -143,7 +144,8 @@ const queries: Record<string, string> = {
 			alphabet,
 			sentence_delimiters AS sentenceDelimiters,
 			whitespaces,
-			intraword_punctuation AS intrawordPunctuation
+			intraword_punctuation AS intrawordPunctuation,
+			template_code AS templateCode
 		FROM language`,
 	getLanguage: `SELECT
 			id,
@@ -153,7 +155,8 @@ const queries: Record<string, string> = {
 			alphabet,
 			sentence_delimiters AS sentenceDelimiters,
 			whitespaces,
-			intraword_punctuation AS intrawordPunctuation
+			intraword_punctuation AS intrawordPunctuation,
+			template_code AS templateCode
 		FROM language WHERE id = :languageId`,
 	addLanguage: `INSERT INTO language (
 			name,
@@ -162,9 +165,10 @@ const queries: Record<string, string> = {
 			alphabet,
 			sentence_delimiters,
 			whitespaces,
-			intraword_punctuation
+			intraword_punctuation,
+			template_code
 		)
-		VALUES (:name, :dictionaryUrl, :shouldShowSpaces, :alphabet, :sentenceDelimiters, :whitespaces, :intrawordPunctuation)`,
+		VALUES (:name, :dictionaryUrl, :shouldShowSpaces, :alphabet, :sentenceDelimiters, :whitespaces, :intrawordPunctuation, :templateCode)`,
 	deleteLanguage: `DELETE FROM language WHERE id = :languageId`,
 	editLanguage: `UPDATE language SET %DYNAMIC% WHERE id = :languageId`,
 	//#endregion

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -21,6 +21,7 @@ const queries: Record<string, string> = {
 		whitespaces TEXT NOT NULL,
 		intraword_punctuation TEXT NOT NULL,
 		template_code TEXT NOT NULL,
+		script_name TEXT NOT NULL,
 		CONSTRAINT pk__language__id PRIMARY KEY (id),
 		CONSTRAINT uq__language__name UNIQUE (name)
 	)`,
@@ -145,7 +146,8 @@ const queries: Record<string, string> = {
 			sentence_delimiters AS sentenceDelimiters,
 			whitespaces,
 			intraword_punctuation AS intrawordPunctuation,
-			template_code AS templateCode
+			template_code AS templateCode,
+			script_name AS scriptName
 		FROM language`,
 	getLanguage: `SELECT
 			id,
@@ -156,7 +158,8 @@ const queries: Record<string, string> = {
 			sentence_delimiters AS sentenceDelimiters,
 			whitespaces,
 			intraword_punctuation AS intrawordPunctuation,
-			template_code AS templateCode
+			template_code AS templateCode,
+			script_name AS scriptName
 		FROM language WHERE id = :languageId`,
 	addLanguage: `INSERT INTO language (
 			name,
@@ -166,9 +169,10 @@ const queries: Record<string, string> = {
 			sentence_delimiters,
 			whitespaces,
 			intraword_punctuation,
-			template_code
+			template_code,
+			script_name
 		)
-		VALUES (:name, :dictionaryUrl, :shouldShowSpaces, :alphabet, :sentenceDelimiters, :whitespaces, :intrawordPunctuation, :templateCode)`,
+		VALUES (:name, :dictionaryUrl, :shouldShowSpaces, :alphabet, :sentenceDelimiters, :whitespaces, :intrawordPunctuation, :templateCode, :scriptName)`,
 	deleteLanguage: `DELETE FROM language WHERE id = :languageId`,
 	editLanguage: `UPDATE language SET %DYNAMIC% WHERE id = :languageId`,
 	//#endregion

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -63,7 +63,8 @@ router.post(
 				req.body.alphabet,
 				req.body.sentenceDelimiters,
 				req.body.whitespaces,
-				req.body.intrawordPunctuation
+				req.body.intrawordPunctuation,
+				req.body.templateCode
 			);
 			res.sendStatus(200);
 		}

--- a/server/src/routers/api-router.ts
+++ b/server/src/routers/api-router.ts
@@ -64,7 +64,8 @@ router.post(
 				req.body.sentenceDelimiters,
 				req.body.whitespaces,
 				req.body.intrawordPunctuation,
-				req.body.templateCode
+				req.body.templateCode,
+				req.body.scriptName
 			);
 			res.sendStatus(200);
 		}


### PR DESCRIPTION
This pull request creates the language-template system. Right now, templates have been creates for **English**, **Japanese** and **Spanish**.

When the user clicks on the _add language_ link, they are first shown a **Language Wizard**, who asks for the target language (the language they want to study) and the auxiliary language (what language they want the definitions to be written in). Afterwards, the language configuration is autocompleted.

If the user doesn't choose an auxiliary language, only the fields that depend solely on the target language will be autocompleted (for example, the regex patterns), while for example the dictionary will have to be chosen by the user.

If the user doesn't choose a target language, they won't be able to choose an auxiliary language either. In that case, the form will have the default values, and the onus will be on the user to choose the values for all the fields.

Additionally, the form now contains a `<select>` where they can choose the language's script. Changing the selection will automatically modify the regex patterns. This way, even if the language is not present in the wizard, the user will not have to go through the tedious work of designing a regex pattern for their target language, as the target script will most likely be available.