### PR TITLE
Create `text_progress_log` table and add prefix to log tables

### DIFF
--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -75,8 +75,8 @@ class DatabaseManager
 		this.runQuery(queries.createPageTable);
 		this.runQuery(queries.createWordTable);
 		this.runQuery(queries.createEntryTable);
-		this.runQuery(queries.createStatusLogTable);
-		this.runQuery(queries.createProgressLogTable);
+		this.runQuery(queries.createWordStatusLogTable);
+		this.runQuery(queries.createTextProgressLogTable);
 
 		// Create indexes
 		this.runQuery(queries.createTextLanguageIdTitleIndex);
@@ -84,12 +84,12 @@ class DatabaseManager
 		this.runQuery(queries.createWordLanguageIdTokenCountContentIndex);
 
 		// Create triggers
-		this.runQuery(queries.createInsertStatusLogAfterInsertWordTrigger);
-		this.runQuery(queries.createInsertStatusLogAfterUpdateWordTrigger);
-		this.runQuery(queries.createDeleteStatusLogAfterDeleteWordTrigger);
-		this.runQuery(queries.createInsertProgressLogAfterInsertTextTrigger);
-		this.runQuery(queries.createInsertProgressLogAfterUpdateTextTrigger);
-		this.runQuery(queries.createDeleteProgressLogAfterDeleteTextTrigger);
+		this.runQuery(queries.createInsertWordStatusLogAfterInsertWordTrigger);
+		this.runQuery(queries.createInsertWordStatusLogAfterUpdateWordTrigger);
+		this.runQuery(queries.createDeleteWordStatusLogAfterDeleteWordTrigger);
+		this.runQuery(queries.createInsertTextProgressLogAfterInsertTextTrigger);
+		this.runQuery(queries.createInsertTextProgressLogAfterUpdateTextTrigger);
+		this.runQuery(queries.createDeleteTextProgressLogAfterDeleteTextTrigger);
 	}
 
 	runQuery(query: string, parameters: Record<string, any> = {}): void

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -87,6 +87,9 @@ class DatabaseManager
 		this.runQuery(queries.createInsertStatusLogAfterInsertWordTrigger);
 		this.runQuery(queries.createInsertStatusLogAfterUpdateWordTrigger);
 		this.runQuery(queries.createDeleteStatusLogAfterDeleteWordTrigger);
+		this.runQuery(queries.createInsertProgressLogAfterInsertTextTrigger);
+		this.runQuery(queries.createInsertProgressLogAfterUpdateTextTrigger);
+		this.runQuery(queries.createDeleteProgressLogAfterDeleteTextTrigger);
 	}
 
 	runQuery(query: string, parameters: Record<string, any> = {}): void

--- a/server/src/database/database-manager.ts
+++ b/server/src/database/database-manager.ts
@@ -76,6 +76,7 @@ class DatabaseManager
 		this.runQuery(queries.createWordTable);
 		this.runQuery(queries.createEntryTable);
 		this.runQuery(queries.createStatusLogTable);
+		this.runQuery(queries.createProgressLogTable);
 
 		// Create indexes
 		this.runQuery(queries.createTextLanguageIdTitleIndex);

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -69,23 +69,23 @@ const queries: Record<string, string> = {
 		CONSTRAINT fk__entry__word_id FOREIGN KEY (word_id) REFERENCES word (id),
 		CONSTRAINT uq__entry__word_id__position UNIQUE (word_id, position)
 	)`,
-	createStatusLogTable: `CREATE TABLE IF NOT EXISTS status_log (
+	createWordStatusLogTable: `CREATE TABLE IF NOT EXISTS word_status_log (
 		id INTEGER,
 		word_id INTEGER NOT NULL,
 		status INTEGER NOT NULL,
 		time_updated INTEGER NOT NULL,
-		CONSTRAINT pk__status_log__id PRIMARY KEY (id),
-		CONSTRAINT fk__status_log__word_id FOREIGN KEY (word_id) REFERENCES word (id)
-		CONSTRAINT uq__status_log__word_id__time_updated UNIQUE (word_id, time_updated)
+		CONSTRAINT pk__word_status_log__id PRIMARY KEY (id),
+		CONSTRAINT fk__word_status_log__word_id FOREIGN KEY (word_id) REFERENCES word (id)
+		CONSTRAINT uq__word_status_log__word_id__time_updated UNIQUE (word_id, time_updated)
 	)`,
-	createProgressLogTable: `CREATE TABLE IF NOT EXISTS progress_log (
+	createTextProgressLogTable: `CREATE TABLE IF NOT EXISTS text_progress_log (
 		id INTEGER,
 		text_id INTEGER NOT NULL,
 		progress REAL NOT NULL,
 		time_updated INTEGER NOT NULL,
-		CONSTRAINT pk__progress_log__id PRIMARY KEY (id),
-		CONSTRAINT fk__progress_log__text_id FOREIGN KEY (text_id) REFERENCES text (id)
-		CONSTRAINT uq__progress_log__text_id__time_updated UNIQUE (text_id, time_updated)
+		CONSTRAINT pk__text_progress_log__id PRIMARY KEY (id),
+		CONSTRAINT fk__text_progress_log__text_id FOREIGN KEY (text_id) REFERENCES text (id)
+		CONSTRAINT uq__text_progress_log__text_id__time_updated UNIQUE (text_id, time_updated)
 	)`,
 	//#endregion
 
@@ -105,11 +105,11 @@ const queries: Record<string, string> = {
 	//#endregion
 
 	//#region Create triggers
-	createInsertStatusLogAfterInsertWordTrigger: `CREATE TRIGGER IF NOT EXISTS
-		tr__insert__status_log__after__insert__word
+	createInsertWordStatusLogAfterInsertWordTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__word_status_log__after__insert__word
 		AFTER INSERT ON word
 		BEGIN
-			INSERT INTO status_log (
+			INSERT INTO word_status_log (
 				word_id,
 				status,
 				time_updated
@@ -120,12 +120,12 @@ const queries: Record<string, string> = {
 				NEW.time_updated
 			);
 		END`,
-	createInsertStatusLogAfterUpdateWordTrigger: `CREATE TRIGGER IF NOT EXISTS
-		tr__insert__status_log__after__update__word
+	createInsertWordStatusLogAfterUpdateWordTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__word_status_log__after__update__word
 		AFTER UPDATE ON word
 		WHEN OLD.status != NEW.status
 		BEGIN
-			INSERT INTO status_log (
+			INSERT INTO word_status_log (
 				word_id,
 				status,
 				time_updated
@@ -136,18 +136,18 @@ const queries: Record<string, string> = {
 				NEW.time_updated
 			);
 		END`,
-	createDeleteStatusLogAfterDeleteWordTrigger: `CREATE TRIGGER IF NOT EXISTS
-		tr__delete__status_log__after__delete__word
+	createDeleteWordStatusLogAfterDeleteWordTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__delete__word_status_log__after__delete__word
 		AFTER DELETE ON word
 		BEGIN
-			DELETE FROM status_log
+			DELETE FROM word_status_log
 			WHERE word_id = OLD.id;
 		END`,
-	createInsertProgressLogAfterInsertTextTrigger: `CREATE TRIGGER IF NOT EXISTS
-		tr__insert__progress_log__after__insert__text
+	createInsertTextProgressLogAfterInsertTextTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__text_progress_log__after__insert__text
 		AFTER INSERT ON text
 		BEGIN
-			INSERT INTO progress_log (
+			INSERT INTO text_progress_log (
 				text_id,
 				progress,
 				time_updated
@@ -158,12 +158,12 @@ const queries: Record<string, string> = {
 				NEW.time_updated
 			);
 		END`,
-	createInsertProgressLogAfterUpdateTextTrigger: `CREATE TRIGGER IF NOT EXISTS
-		tr__insert__progress_log__after__update__text
+	createInsertTextProgressLogAfterUpdateTextTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__text_progress_log__after__update__text
 		AFTER UPDATE ON text
 		WHEN OLD.progress != NEW.progress
 		BEGIN
-			INSERT INTO progress_log (
+			INSERT INTO text_progress_log (
 				text_id,
 				progress,
 				time_updated
@@ -174,11 +174,11 @@ const queries: Record<string, string> = {
 				NEW.time_updated
 			);
 		END`,
-	createDeleteProgressLogAfterDeleteTextTrigger: `CREATE TRIGGER IF NOT EXISTS
-		tr__delete__progress_log__after__delete__text
+	createDeleteTextProgressLogAfterDeleteTextTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__delete__text_progress_log__after__delete__text
 		AFTER DELETE ON text
 		BEGIN
-			DELETE FROM progress_log
+			DELETE FROM text_progress_log
 			WHERE text_id = OLD.id;
 		END`,
 	//#endregion

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -155,7 +155,7 @@ const queries: Record<string, string> = {
 			VALUES (
 				NEW.id,
 				NEW.progress,
-				NEW.time_updated
+				UNIXEPOCH()
 			);
 		END`,
 	createInsertTextProgressLogAfterUpdateTextTrigger: `CREATE TRIGGER IF NOT EXISTS
@@ -171,7 +171,7 @@ const queries: Record<string, string> = {
 			VALUES (
 				NEW.id,
 				NEW.progress,
-				NEW.time_updated
+				UNIXEPOCH()
 			);
 		END`,
 	createDeleteTextProgressLogAfterDeleteTextTrigger: `CREATE TRIGGER IF NOT EXISTS

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -78,6 +78,15 @@ const queries: Record<string, string> = {
 		CONSTRAINT fk__status_log__word_id FOREIGN KEY (word_id) REFERENCES word (id)
 		CONSTRAINT uq__status_log__word_id__time_updated UNIQUE (word_id, time_updated)
 	)`,
+	createProgressLogTable: `CREATE TABLE IF NOT EXISTS progress_log (
+		id INTEGER,
+		text_id INTEGER NOT NULL,
+		progress REAL NOT NULL,
+		time_updated INTEGER NOT NULL,
+		CONSTRAINT pk__progress_log__id PRIMARY KEY (id),
+		CONSTRAINT fk__progress_log__text_id FOREIGN KEY (text_id) REFERENCES text (id)
+		CONSTRAINT uq__progress_log__text_id__time_updated UNIQUE (text_id, time_updated)
+	)`,
 	//#endregion
 
 	//#region Create indexes

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -403,7 +403,7 @@ const queries: Record<string, string> = {
 				word_id,
 				status AS first_status,
 				MIN(time_updated) AS first_time_updated
-			FROM status_log
+			FROM word_status_log
 			WHERE time_updated >= strftime('%s', 'now') - 86400
 			GROUP BY word_id
 		),
@@ -412,7 +412,7 @@ const queries: Record<string, string> = {
 				word_id,
 				status AS last_status,
 				MAX(time_updated) AS last_time_updated
-			FROM status_log
+			FROM word_status_log
 			WHERE time_updated >= strftime('%s', 'now') - 86400
 			GROUP BY word_id
 		)

--- a/server/src/database/queries.ts
+++ b/server/src/database/queries.ts
@@ -143,6 +143,44 @@ const queries: Record<string, string> = {
 			DELETE FROM status_log
 			WHERE word_id = OLD.id;
 		END`,
+	createInsertProgressLogAfterInsertTextTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__progress_log__after__insert__text
+		AFTER INSERT ON text
+		BEGIN
+			INSERT INTO progress_log (
+				text_id,
+				progress,
+				time_updated
+			)
+			VALUES (
+				NEW.id,
+				NEW.progress,
+				NEW.time_updated
+			);
+		END`,
+	createInsertProgressLogAfterUpdateTextTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__insert__progress_log__after__update__text
+		AFTER UPDATE ON text
+		WHEN OLD.progress != NEW.progress
+		BEGIN
+			INSERT INTO progress_log (
+				text_id,
+				progress,
+				time_updated
+			)
+			VALUES (
+				NEW.id,
+				NEW.progress,
+				NEW.time_updated
+			);
+		END`,
+	createDeleteProgressLogAfterDeleteTextTrigger: `CREATE TRIGGER IF NOT EXISTS
+		tr__delete__progress_log__after__delete__text
+		AFTER DELETE ON text
+		BEGIN
+			DELETE FROM progress_log
+			WHERE text_id = OLD.id;
+		END`,
 	//#endregion
 
 	//#region Language


### PR DESCRIPTION
- A `text_progress_log` table (initially `progress_log`) has been created to log updates in texts' progress column. This table works pretty much in the same way as `status_log`.
- Both log tables have been added a prefix to indicate what table the logged column is taken from. This is to make the schema more robust, in case there are name collisions in the future:
  - `status_log` is now named `word_status_log`.
  - `progress_log` is now named `text_progress_log`.